### PR TITLE
chore: add default config for wallet verification message

### DIFF
--- a/pkg/request/verification.go
+++ b/pkg/request/verification.go
@@ -20,8 +20,6 @@ func (input *NewGuildConfigWalletVerificationMessageRequest) Validate() error {
 		return fmt.Errorf("missing guild_id")
 	case input.VerifyChannelID == "":
 		return fmt.Errorf("missing verify_channel_id")
-	case input.Content == "" && input.EmbeddedMessage == nil:
-		return fmt.Errorf("content or embedded_message is required")
 	}
 
 	return nil


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add default config message when no content or embed message is provided

**Media (Loom or gif)**

![image](https://user-images.githubusercontent.com/37581250/169247873-e70a6593-7248-454b-933f-39a74e29aaa7.png)

![image](https://user-images.githubusercontent.com/37581250/169247275-7fc7fd8f-790f-4be0-bc07-8f14dc1ebf6e.png)


