### PR TITLE
chore: fix gas limit

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -219,7 +219,6 @@ func (ch *Chain) transferToken(fromAcc accounts.Account, toAcc accounts.Account,
 	if err != nil {
 		return nil, 0, err
 	}
-	gasLimit *= 3
 
 	tx := types.NewTransaction(nonce, tokenAddress, value, gasLimit, gasPrice, data)
 


### PR DESCRIPTION
## Describe

Transfer token must be follow the docs [goethereumbook](https://goethereumbook.org/en/transfer-tokens/)

To make new transaction need: `gas_limit * gas_price + value < balance`. In the old source code, `gas_limit` was x3 the real value and this may be cause the error `insufficient funds for gas * price + value`. So just remove `gas_limit` may be resolve the problem.
