### PR TITLE
chore: update collection images

### DIFF
--- a/pkg/entities/nfts.go
+++ b/pkg/entities/nfts.go
@@ -568,3 +568,25 @@ func (e *Entity) GetNFTCollectionByAddressChain(address, chainId string) (*model
 
 	return collection, nil
 }
+
+func (e *Entity) UpdateNFTCollection(address string) error {
+	collection, err := e.repo.NFTCollection.GetByAddress(address)
+	if err != nil {
+		e.log.Errorf(err, "[e.UpdateNFTCollection] cannot get address")
+		return err
+	}
+	// if image already valid, function return same string
+	image, err := e.svc.Cloud.HostImageToGCS(collection.Image, strings.ReplaceAll(collection.Name, " ", ""))
+	if err != nil {
+		e.log.Errorf(err, "[e.UpdateNFTCollection] cannot host image")
+		return err
+	}
+	if image != collection.Image {
+		err := e.repo.NFTCollection.UpdateImage(address, image)
+		if err != nil {
+			e.log.Errorf(err, "[e.UpdateNFTCollection] cannot update image")
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/handler/nfts.go
+++ b/pkg/handler/nfts.go
@@ -245,3 +245,19 @@ func (h *Handler) GetNFTCollectionByAddressChain(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, data)
 }
+
+func (h *Handler) UpdateNFTCollection(c *gin.Context) {
+	address := c.Param("address")
+	if address == "" {
+		h.log.Info("[handler.GetNFTCollectionByAddressChain] - address empty")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "address is required"})
+		return
+	}
+	err := h.entities.UpdateNFTCollection(address)
+	if err != nil {
+		h.log.Fields(logger.Fields{"address": address}).Error(err, "[handler.UpdateNFTCollection] - failed to update collection")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "ok"})
+}

--- a/pkg/repo/nft_collection/mocks/store.go
+++ b/pkg/repo/nft_collection/mocks/store.go
@@ -216,3 +216,17 @@ func (mr *MockStoreMockRecorder) ListByGuildID(guildID interface{}) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByGuildID", reflect.TypeOf((*MockStore)(nil).ListByGuildID), guildID)
 }
+
+// UpdateImage mocks base method.
+func (m *MockStore) UpdateImage(address, image string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateImage", address, image)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateImage indicates an expected call of UpdateImage.
+func (mr *MockStoreMockRecorder) UpdateImage(address, image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImage", reflect.TypeOf((*MockStore)(nil).UpdateImage), address, image)
+}

--- a/pkg/repo/nft_collection/pg.go
+++ b/pkg/repo/nft_collection/pg.go
@@ -119,3 +119,7 @@ func (pg *pg) GetNewListed(interval int, page int, size int) ([]model.NewListedN
 		Offset(size * page).
 		Find(&collection).Error
 }
+
+func (pg *pg) UpdateImage(address string, image string) error {
+	return pg.db.Table("nft_collections").Where("address=?", address).Update("image", image).Error
+}

--- a/pkg/repo/nft_collection/store.go
+++ b/pkg/repo/nft_collection/store.go
@@ -17,4 +17,5 @@ type Store interface {
 	ListAllWithPaging(page int, size int) ([]model.NFTCollection, int64, error)
 	ListAllNFTCollectionConfigs() ([]model.NFTCollectionConfig, error)
 	ListByGuildID(guildID string) ([]model.NFTCollection, error)
+	UpdateImage(address string, image string) error
 }

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -202,6 +202,7 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 			collectionsGroup.GET("/stats", h.GetCollectionCount)
 			collectionsGroup.GET("", h.GetNFTCollections)
 			collectionsGroup.POST("", h.CreateNFTCollection)
+			collectionsGroup.PATCH("/:address", h.UpdateNFTCollection) //to update collection images, delete after use
 			collectionsGroup.GET("/:symbol", h.GetNFTTokens)
 			collectionsGroup.GET("/:symbol/tickers", h.GetNFTCollectionTickers)
 			collectionsGroup.GET("/address/:address", h.GetNFTCollectionByAddressChain)


### PR DESCRIPTION
**What does this PR do?**

- An API to update collection image to GCS hosted if needed, `PATCH: /api/v1/nfts/collections/<collection_address>`, no request body
