### PR TITLE
chore: guild default tokens

### DIFF
--- a/migrations/schemas/20220821150936-alter_guild_user_activity.sql
+++ b/migrations/schemas/20220821150936-alter_guild_user_activity.sql
@@ -1,0 +1,6 @@
+
+-- +migrate Up
+ALTER TABLE guild_user_activity_logs ALTER COLUMN guild_id DROP NOT NULL;
+
+-- +migrate Down
+ALTER TABLE guild_user_activity_logs ALTER COLUMN guild_id SET NOT NULL;

--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -50,13 +50,28 @@ func (e *Entity) UpsertSalesTrackerConfig(req request.UpsertSalesTrackerConfigRe
 	}
 	return nil
 }
-func (e *Entity) GetGuildTokens(guildID string) ([]model.GuildConfigToken, error) {
+func (e *Entity) GetGuildTokens(guildID string) ([]model.Token, error) {
+	if guildID == "" {
+		tokens, err := e.repo.Token.GetDefaultTokens()
+		if err != nil {
+			e.log.Error(err, "[Entity][GetGuildTokens] repo.Token.GetDefaultTokens failed")
+			return nil, err
+		}
+		return tokens, nil
+	}
+
 	guildTokens, err := e.repo.GuildConfigToken.GetByGuildID(guildID)
 	if err != nil {
+		e.log.Error(err, "[Entity][GetGuildTokens] repo.GuildConfigToken.GetByGuildID failed")
 		return nil, err
 	}
 
-	return guildTokens, nil
+	var data []model.Token
+	for _, gToken := range guildTokens {
+		data = append(data, *gToken.Token)
+	}
+
+	return data, nil
 }
 
 func (e *Entity) UpsertGuildTokenConfig(req request.UpsertGuildTokenConfigRequest) error {

--- a/pkg/entities/tokens.go
+++ b/pkg/entities/tokens.go
@@ -115,15 +115,6 @@ func (e *Entity) GetDefaultToken(guildID string) (*model.Token, error) {
 	return &token, nil
 }
 
-func (e *Entity) GetGlobalDefaultToken() ([]model.Token, error) {
-	tokens, err := e.repo.Token.GetDefaultTokens()
-	if err != nil {
-		e.log.Error(err, "[Entity][GetGlobalDefaultToken] repo.Token.GetDefaultTokens failed")
-		return nil, err
-	}
-	return tokens, nil
-}
-
 func (e *Entity) SetDefaultToken(req request.ConfigDefaultTokenRequest) error {
 	_, err := e.repo.DiscordGuilds.GetByID(req.GuildID)
 	if err != nil {

--- a/pkg/handler/configs.go
+++ b/pkg/handler/configs.go
@@ -77,17 +77,6 @@ func (h *Handler) GetSalesTrackerConfig(c *gin.Context) {
 func (h *Handler) GetGuildTokens(c *gin.Context) {
 	guildID := c.Query("guild_id")
 	// if guild id empty, return global default tokens
-	if guildID == "" {
-		defaultTokens, err := h.entities.GetGlobalDefaultToken()
-		if err != nil {
-			h.log.Error(err, "[handler.GetGuildTokens] - failed to get default tokens")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-		c.JSON(http.StatusOK, gin.H{"data": defaultTokens})
-		return
-	}
-
 	guildTokens, err := h.entities.GetGuildTokens(guildID)
 	if err != nil {
 		h.log.Fields(logger.Fields{"guildID": guildID}).Error(err, "[handler.GetGuildTokens] - failed to get guild tokens")
@@ -95,12 +84,7 @@ func (h *Handler) GetGuildTokens(c *gin.Context) {
 		return
 	}
 
-	var data []model.Token
-	for _, gToken := range guildTokens {
-		data = append(data, *gToken.Token)
-	}
-
-	c.JSON(http.StatusOK, gin.H{"data": data})
+	c.JSON(http.StatusOK, gin.H{"data": guildTokens})
 }
 
 func (h *Handler) UpsertGuildTokenConfig(c *gin.Context) {

--- a/pkg/handler/defi.go
+++ b/pkg/handler/defi.go
@@ -67,12 +67,6 @@ func (h *Handler) InDiscordWalletWithdraw(c *gin.Context) {
 
 func (h *Handler) InDiscordWalletBalances(c *gin.Context) {
 	guildID := c.Query("guild_id")
-	if guildID == "" {
-		h.log.Info("[handler.InDiscordWalletBalances] - guild id empty")
-		c.JSON(http.StatusBadRequest, gin.H{"error": "guild_id is required"})
-		return
-	}
-
 	discordID := c.Query("discord_id")
 	if discordID == "" {
 		h.log.Info("[handler.InDiscordWalletBalances] - discord id empty")

--- a/pkg/repo/guild_user_activity_log/mocks/store.go
+++ b/pkg/repo/guild_user_activity_log/mocks/store.go
@@ -47,3 +47,17 @@ func (mr *MockStoreMockRecorder) CreateOne(record interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOne", reflect.TypeOf((*MockStore)(nil).CreateOne), record)
 }
+
+// CreateOneNoGuild mocks base method.
+func (m *MockStore) CreateOneNoGuild(record model.GuildUserActivityLog) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOneNoGuild", record)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOneNoGuild indicates an expected call of CreateOneNoGuild.
+func (mr *MockStoreMockRecorder) CreateOneNoGuild(record interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOneNoGuild", reflect.TypeOf((*MockStore)(nil).CreateOneNoGuild), record)
+}

--- a/pkg/repo/guild_user_activity_log/pg.go
+++ b/pkg/repo/guild_user_activity_log/pg.go
@@ -16,3 +16,7 @@ func NewPG(db *gorm.DB) Store {
 func (pg *pg) CreateOne(record model.GuildUserActivityLog) error {
 	return pg.db.Create(&record).Error
 }
+
+func (pg *pg) CreateOneNoGuild(record model.GuildUserActivityLog) error {
+	return pg.db.Select("UserID", "ActivityName").Create(&record).Error
+}

--- a/pkg/repo/guild_user_activity_log/store.go
+++ b/pkg/repo/guild_user_activity_log/store.go
@@ -4,4 +4,5 @@ import "github.com/defipod/mochi/pkg/model"
 
 type Store interface {
 	CreateOne(record model.GuildUserActivityLog) error
+	CreateOneNoGuild(record model.GuildUserActivityLog) error
 }

--- a/pkg/service/coingecko/mocks/service.go
+++ b/pkg/service/coingecko/mocks/service.go
@@ -113,18 +113,3 @@ func (mr *MockServiceMockRecorder) SearchCoins(query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCoins", reflect.TypeOf((*MockService)(nil).SearchCoins), query)
 }
-
-// TokenCompare mocks base method.
-func (m *MockService) TokenCompare(sourceSymbolInfo, targetSymbolInfo [][]float32) (*response.TokenCompareReponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TokenCompare", sourceSymbolInfo, targetSymbolInfo)
-	ret0, _ := ret[0].(*response.TokenCompareReponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TokenCompare indicates an expected call of TokenCompare.
-func (mr *MockServiceMockRecorder) TokenCompare(sourceSymbolInfo, targetSymbolInfo interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TokenCompare", reflect.TypeOf((*MockService)(nil).TokenCompare), sourceSymbolInfo, targetSymbolInfo)
-}


### PR DESCRIPTION
**What does this PR do?**

-  `GET: /configs/tokens?guild_id=` returns global default tokens when `guild_id=""`
- Activity log `guild_id` is nullable to log DM activities

![image](https://user-images.githubusercontent.com/84314071/185886612-affe92db-3360-4955-bfc6-7cdf97559d2f.png)
![image](https://user-images.githubusercontent.com/84314071/185886654-ec4a8076-8f3e-44a5-bfa1-11ba787c33cb.png)
