### PR TITLE
feat: more moderation logs

### DIFF
--- a/cmd/update-user-role/main.go
+++ b/cmd/update-user-role/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/defipod/mochi/pkg/entities"
 	"github.com/defipod/mochi/pkg/job"
 	"github.com/defipod/mochi/pkg/logger"
+	"github.com/defipod/mochi/pkg/service"
 )
 
 func main() {
@@ -13,11 +14,19 @@ func main() {
 	err := entities.Init(cfg, log)
 	if err != nil {
 		log.Fatal(err, "failed to init entities")
+		return
+	}
+
+	svc, err := service.NewService(cfg, log)
+	if err != nil {
+		log.Fatal(err, "service.NewService failed")
+		return
 	}
 
 	log.Info("start job updateUserRoles ...")
-	if err := job.NewUpdateUserRolesJob(entities.Get(), log).Run(); err != nil {
+	if err := job.NewUpdateUserRolesJob(entities.Get(), svc, log).Run(); err != nil {
 		log.Fatal(err, "failed to run job")
+		return
 	}
 
 	log.Info("done")

--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/defipod/mochi/pkg/logger"
 	"github.com/defipod/mochi/pkg/model"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/response"
@@ -99,38 +98,6 @@ func (e *Entity) GetUserRoleByLevel(guildID string, level int) (string, error) {
 	}
 
 	return config.RoleID, nil
-}
-
-func (e *Entity) RemoveGuildMemberRoles(guildID string, rolesToRemove map[string]string) error {
-	for userID, roleID := range rolesToRemove {
-		gMemberRoleLog := e.log.Fields(logger.Fields{
-			"guildId": guildID,
-			"userId":  userID,
-			"roleId":  roleID,
-		})
-		if err := e.discord.GuildMemberRoleRemove(guildID, userID, roleID); err != nil {
-			gMemberRoleLog.Error(err, "[Entity][RemoveGuildMemberRoles] discord.GuildMemberRoleRemove failed")
-			return err
-		}
-		gMemberRoleLog.Info("[Entity][RemoveGuildMemberRoles] discord.GuildMemberRoleRemove executed successfully")
-	}
-	return nil
-}
-
-func (e *Entity) AddGuildMemberRoles(guildID string, rolesToAdd map[string]string) error {
-	for userID, roleID := range rolesToAdd {
-		gMemberRoleLog := e.log.Fields(logger.Fields{
-			"guildId": guildID,
-			"userId":  userID,
-			"roleId":  roleID,
-		})
-		if err := e.discord.GuildMemberRoleAdd(guildID, userID, roleID); err != nil {
-			gMemberRoleLog.Error(err, "[Entity][AddGuildMemberRoles] discord.GuildMemberRoleAdd failed")
-			return err
-		}
-		gMemberRoleLog.Info("[Entity][AddGuildMemberRoles] discord.GuildMemberRoleAdd executed successfully")
-	}
-	return nil
 }
 
 func (e *Entity) AddGuildMemberRole(guildID, userID, roleID string) error {

--- a/pkg/entities/guild.go
+++ b/pkg/entities/guild.go
@@ -53,7 +53,8 @@ func (e *Entity) GetGuilds() (*response.GetGuildsResponse, error) {
 			Name:         g.Name,
 			BotScopes:    g.BotScopes,
 			Alias:        g.Alias,
-			LogChannelID: g.GuildConfigInviteTracker.ChannelID,
+			LogChannelID: g.GuildConfigInviteTracker.ChannelID, // TODO: refactor (rename)
+			LogChannel:   g.LogChannel,
 		})
 	}
 
@@ -74,7 +75,8 @@ func (e *Entity) GetGuild(guildID string) (*response.GetGuildResponse, error) {
 		Name:         guild.Name,
 		BotScopes:    guild.BotScopes,
 		Alias:        guild.Alias,
-		LogChannelID: guild.GuildConfigInviteTracker.ChannelID,
+		LogChannel:   guild.LogChannel,
+		LogChannelID: guild.GuildConfigInviteTracker.ChannelID, // TODO: refactor (rename)
 		GlobalXP:     guild.GlobalXP,
 	}, nil
 }

--- a/pkg/entities/user.go
+++ b/pkg/entities/user.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/defipod/mochi/pkg/logger"
 	"github.com/defipod/mochi/pkg/model"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/response"
@@ -140,9 +141,11 @@ func (e *Entity) HandleUserActivities(req *request.HandleUserActivityRequest) (*
 
 	role, err := e.GetRoleByGuildLevelConfig(req.GuildID, req.UserID)
 	if err != nil {
-		e.log.Errorf(err, "[HandleUserActivities] - SendLevelUpMessage failed - guild %s, user %s", req.GuildID, req.UserID)
+		e.log.Fields(logger.Fields{
+			"guildId": req.GuildID,
+			"userId":  req.UserID,
+		}).Errorf(err, "[HandleUserActivities] - SendLevelUpMessage failed")
 	} else {
-		e.log.Infof("[HandleUserActivities] - SendLevelUpMessage - userXP: %v, role: %s, res: %v", userXP, role, res)
 		e.svc.Discord.SendLevelUpMessage(latestUserXP.Guild.LogChannel, role, res)
 	}
 	return res, nil

--- a/pkg/response/guild.go
+++ b/pkg/response/guild.go
@@ -9,6 +9,7 @@ type GetGuildResponse struct {
 	Name         string   `json:"name"`
 	BotScopes    []string `json:"bot_scopes"`
 	Alias        string   `json:"alias"`
+	LogChannel   string   `json:"log_channel"`
 	LogChannelID string   `json:"log_channel_id"`
 	GlobalXP     bool     `json:"global_xp"`
 }

--- a/pkg/service/coingecko/mocks/service.go
+++ b/pkg/service/coingecko/mocks/service.go
@@ -113,18 +113,3 @@ func (mr *MockServiceMockRecorder) SearchCoins(query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCoins", reflect.TypeOf((*MockService)(nil).SearchCoins), query)
 }
-
-// TokenCompare mocks base method.
-func (m *MockService) TokenCompare(sourceSymbolInfo, targetSymbolInfo [][]float32) (*response.TokenCompareReponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TokenCompare", sourceSymbolInfo, targetSymbolInfo)
-	ret0, _ := ret[0].(*response.TokenCompareReponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TokenCompare indicates an expected call of TokenCompare.
-func (mr *MockServiceMockRecorder) TokenCompare(sourceSymbolInfo, targetSymbolInfo interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TokenCompare", reflect.TypeOf((*MockService)(nil).TokenCompare), sourceSymbolInfo, targetSymbolInfo)
-}

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -203,3 +203,32 @@ func (d *Discord) NotifyStealAveragePrice(price float64, avg float64, url string
 
 	return nil
 }
+
+func (d *Discord) SendUpdateRolesLog(guildID, logChannelID, userID, roleID, _type string) error {
+	if guildID == "" || logChannelID == "" || userID == "" || roleID == "" {
+		return nil
+	}
+
+	member, err := d.session.GuildMember(guildID, userID)
+	if err != nil {
+		d.log.Errorf(err, "[svc.Discord.SendUpdateRolesLog] - session.GuildMember failed %s", userID)
+		return err
+	}
+
+	description := fmt.Sprintf("<@%s> has been assigned a new role\n**Type**: %s\n**Role**: <@&%s>", userID, _type, roleID)
+	msgEmbed := discordgo.MessageEmbed{
+		Title:       "Role updated",
+		Description: description,
+		Color:       mochiLogColor,
+		Timestamp:   time.Now().Format("2006-01-02T15:04:05Z07:00"),
+		Thumbnail: &discordgo.MessageEmbedThumbnail{
+			URL: member.AvatarURL(""),
+		},
+	}
+
+	_, err = d.session.ChannelMessageSendEmbed(logChannelID, &msgEmbed)
+	if err != nil {
+		return fmt.Errorf("[svc.Discord.SendUpdateRolesLog] - ChannelMessageSendEmbed failed to channel %s: %s", logChannelID, err.Error())
+	}
+	return nil
+}

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -115,3 +115,17 @@ func (mr *MockServiceMockRecorder) SendLevelUpMessage(logChannelID, role, uActiv
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendLevelUpMessage", reflect.TypeOf((*MockService)(nil).SendLevelUpMessage), logChannelID, role, uActivity)
 }
+
+// SendUpdateRolesLog mocks base method.
+func (m *MockService) SendUpdateRolesLog(guildID, logChannelID, userID, roleID, _type string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendUpdateRolesLog", guildID, logChannelID, userID, roleID, _type)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendUpdateRolesLog indicates an expected call of SendUpdateRolesLog.
+func (mr *MockServiceMockRecorder) SendUpdateRolesLog(guildID, logChannelID, userID, roleID, _type interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendUpdateRolesLog", reflect.TypeOf((*MockService)(nil).SendUpdateRolesLog), guildID, logChannelID, userID, roleID, _type)
+}

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -1,12 +1,17 @@
 package discord
 
-import "github.com/defipod/mochi/pkg/response"
+import (
+	"github.com/defipod/mochi/pkg/response"
+)
 
 type Service interface {
-	NotifyNewGuild(newGuildID string, count int) error
 	NotifyAddNewCollection(guildID string, collectionName string, symbol string, chain string, image string) error
-	SendGuildActivityLogs(channelID, userID, title, description string) error
-	SendLevelUpMessage(logChannelID, role string, uActivity *response.HandleUserActivityResponse)
 	NotifyStealFloorPrice(price float64, floor float64, url string, name string, image string) error
 	NotifyStealAveragePrice(price float64, floor float64, url string, name string, image string) error
+
+	// moderation logs
+	NotifyNewGuild(newGuildID string, count int) error
+	SendUpdateRolesLog(guildID, logChannelID, userID, roleID, _type string) error
+	SendGuildActivityLogs(channelID, userID, title, description string) error
+	SendLevelUpMessage(logChannelID, role string, uActivity *response.HandleUserActivityResponse)
 }


### PR DESCRIPTION
**What does this PR do?**
Currently we send moderation logs to configured channel via `$log`, but only applied for `tip` and `levelup`
Now we are sending logs for more activities
- [x] withdraw
- [x] airdrop
- [x] role assignment via level-role
- [x] role assignment via nft-role
