### PR TITLE
fix: default message

### DIFF
--- a/pkg/entities/default_role.go
+++ b/pkg/entities/default_role.go
@@ -1,13 +1,16 @@
 package entities
 
 import (
+	"github.com/defipod/mochi/pkg/logger"
 	"github.com/defipod/mochi/pkg/model"
 	"github.com/defipod/mochi/pkg/response"
+	"gorm.io/gorm"
 )
 
 func (e *Entity) GetDefaultRoleByGuildID(guildID string) (*response.DefaultRoleResponse, error) {
 	role, err := e.repo.GuildConfigDefaultRole.GetAllByGuildID(guildID)
-	if err != nil {
+	if err != nil && err != gorm.ErrRecordNotFound {
+		e.log.Fields(logger.Fields{"guildID": guildID}).Error(err, "[Entity][GetDefaultRoleByGuildID] failed to get default role by guild id")
 		return nil, err
 	}
 
@@ -15,7 +18,7 @@ func (e *Entity) GetDefaultRoleByGuildID(guildID string) (*response.DefaultRoleR
 	res.Success = true
 	res.Data = response.DefaultRole{
 		RoleID:  role.RoleID,
-		GuildID: role.GuildID,
+		GuildID: guildID,
 	}
 
 	return &res, nil

--- a/pkg/entities/default_role.go
+++ b/pkg/entities/default_role.go
@@ -15,7 +15,7 @@ func (e *Entity) GetDefaultRoleByGuildID(guildID string) (*response.DefaultRoleR
 	}
 
 	var res response.DefaultRoleResponse
-	res.Success = true
+	res.Ok = true
 	res.Data = response.DefaultRole{
 		RoleID:  role.RoleID,
 		GuildID: guildID,

--- a/pkg/entities/user.go
+++ b/pkg/entities/user.go
@@ -119,6 +119,9 @@ func (e *Entity) HandleUserActivities(req *request.HandleUserActivityRequest) (*
 		EarnedXP:     earnedXP,
 		CreatedAt:    req.Timestamp,
 	}); err != nil {
+		e.log.
+			Fields(logger.Fields{"guildID": req.GuildID, "userID": req.UserID, "action": req.Action}).
+			Error(err, "[Entity][HandleUserActivities] failed to create guild_user_activity_logs")
 		return nil, err
 	}
 

--- a/pkg/entities/webhook.go
+++ b/pkg/entities/webhook.go
@@ -246,6 +246,20 @@ func (e *Entity) replyGmGn(streak *model.DiscordUserGMStreak, channelID, discord
 }
 
 func (e *Entity) ChatXPIncrease(message *discordgo.Message) (*response.HandleUserActivityResponse, error) {
+	if message.Content == "" {
+		return &response.HandleUserActivityResponse{
+			GuildID:      message.GuildID,
+			ChannelID:    message.ChannelID,
+			UserID:       message.Author.ID,
+			Action:       "default",
+			AddedXP:      0,
+			CurrentXP:    0,
+			CurrentLevel: 0,
+			Timestamp:    message.Timestamp,
+			LevelUp:      false,
+		}, nil
+	}
+
 	xpID := fmt.Sprintf(`%s_%s_chat_xp_cooldown`, message.Author.ID, message.GuildID)
 
 	exists, err := e.cache.GetBool(xpID)

--- a/pkg/handler/default_roles.go
+++ b/pkg/handler/default_roles.go
@@ -1,14 +1,12 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/defipod/mochi/pkg/logger"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/response"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 )
 
 func (h *Handler) GetDefaultRolesByGuildID(c *gin.Context) {
@@ -21,10 +19,6 @@ func (h *Handler) GetDefaultRolesByGuildID(c *gin.Context) {
 	data, err := h.entities.GetDefaultRoleByGuildID(guildID)
 	if err != nil {
 		h.log.Fields(logger.Fields{"guildID": guildID}).Error(err, "[handler.GetDefaultRolesByGuildID] - failed to get default roles")
-		if err == gorm.ErrRecordNotFound {
-			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("cannot find default role of guild %s", guildID)})
-			return
-		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/pkg/handler/default_roles.go
+++ b/pkg/handler/default_roles.go
@@ -47,8 +47,8 @@ func (h *Handler) CreateDefaultRole(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response.DefaultRoleResponse{
-		Data:    defaultRole,
-		Success: true,
+		Data: defaultRole,
+		Ok:   true,
 	})
 }
 

--- a/pkg/handler/webhook_test.go
+++ b/pkg/handler/webhook_test.go
@@ -114,7 +114,7 @@ func Test_HandleDiscordWebhook(t *testing.T) {
 		},
 		{
 			name: "internal server error - invalid guild ID",
-			args: args{request.MESSAGE_CREATE, argsData{author{"760874365037314100"}, "", "895659000996200508", time.Now(), ""}},
+			args: args{request.MESSAGE_CREATE, argsData{author{"760874365037314100"}, "", "895659000996200508", time.Now(), "abc"}},
 			want: result{
 				code: 500,
 				err:  nil,

--- a/pkg/response/default_role.go
+++ b/pkg/response/default_role.go
@@ -6,6 +6,6 @@ type DefaultRole struct {
 }
 
 type DefaultRoleResponse struct {
-	Data    DefaultRole `json:"data"`
-	Success bool        `json:"success"`
+	Data DefaultRole `json:"data"`
+	Ok   bool        `json:"ok"`
 }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix default message
-   [x] Return empty role_id when default role not found

**Describe**

When new user join server, 2 event will be triggered:
  - `messageCreate`
  - `guildMemberAdd`

`messageCreate` run first and no user in database to process this event. So I consider it as a default action and does not create activity log in database.

**Media (Loom or gif)**
- Default role:
![image](https://user-images.githubusercontent.com/104887632/186152048-60e9625e-0061-4595-a2fa-2bcaa2470e04.png)

- Errors:
![image](https://user-images.githubusercontent.com/104887632/186149212-37a26a69-6863-4924-bfae-0c4e5038cd23.png)
![image](https://user-images.githubusercontent.com/104887632/186149276-290a64e0-e1b4-45ff-b605-000c206d84fa.png)
