### PR TITLE
chore: create user if not exist

### DIFF
--- a/pkg/entities/webhook.go
+++ b/pkg/entities/webhook.go
@@ -141,6 +141,17 @@ func (e *Entity) HandleDiscordMessage(message *discordgo.Message) (*response.Han
 		channelID      = message.ChannelID
 	)
 
+	// message.Content == "" is default message when new user join server
+	if message.Content == "" {
+		return nil, nil
+	}
+	if err := e.CreateUserIfNotExists(discordID, authorUsername); err != nil {
+		e.log.Fields(logger.Fields{"userID": discordID, "username": authorUsername}).Error(err, "[Entity][HandleDiscordMessage] failed to create user")
+	}
+	if err := e.CreateGuildUserIfNotExists(guildID, discordID, ""); err != nil {
+		e.log.Fields(logger.Fields{"userID": discordID, "guildID": guildID}).Error(err, "[Entity][HandleDiscordMessage] failed to create guild user")
+	}
+
 	isGmMessage := message.Content == "gm" || message.Content == "gn"
 
 	switch {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Create user if not exist

**Description**

When bot is added to new server, it does have info of users in this server. So when user send message, bot cannot handle this and return error.

**Media (Loom or gif)**

Error:
![image](https://user-images.githubusercontent.com/104887632/186622118-fb9f0f8d-752a-4731-bfa1-1dba5611cd0d.png)

