### PR TITLE
fix: invite tracker auto remove user wallet

### DIFF
--- a/pkg/handler/webhook.go
+++ b/pkg/handler/webhook.go
@@ -8,7 +8,6 @@ import (
 	"github.com/defipod/mochi/pkg/logger"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/defipod/mochi/pkg/model"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/response"
 	"github.com/gin-gonic/gin"
@@ -58,75 +57,21 @@ func (h *Handler) handleGuildMemberAdd(c *gin.Context, data json.RawMessage) {
 }
 
 func (h *Handler) handleInviteTracker(c *gin.Context, invitee *discordgo.Member) {
-	var response response.HandleInviteHistoryResponse
-
 	inviter, isVanity, err := h.entities.FindInviter(invitee.GuildID)
 	if err != nil {
 		h.log.Fields(logger.Fields{"invitee": invitee}).Error(err, "[handler.handleInviteTracker] - failed to find inviter")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+
+	response, err := h.entities.HandleInviteTracker(inviter, invitee)
+	if err != nil {
+		h.log.Fields(logger.Fields{"inviter": inviter, "invitee": invitee}).Error(err, "[handler.handleInviteTracker] - failed to handle invite tracker")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	response.IsVanity = isVanity
 
-	if inviter != nil {
-		if err := h.entities.CreateUser(request.CreateUserRequest{
-			ID:       inviter.User.ID,
-			Username: inviter.User.Username,
-			Nickname: inviter.Nick,
-			GuildID:  inviter.GuildID,
-		}); err != nil {
-			h.log.Fields(logger.Fields{"inviterID": inviter.User.ID, "inviterUsrName": inviter.User.Username, "inviterNickName": inviter.Nick, "inviterGuildID": inviter.GuildID}).Error(err, "[handler.handleInviteTracker] - failed to create user")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-		response.InviterID = inviter.User.ID
-		if inviter.User.Bot {
-			response.IsBot = true
-		}
-	}
-	if invitee != nil {
-		if err := h.entities.CreateUser(request.CreateUserRequest{
-			ID:        invitee.User.ID,
-			Username:  invitee.User.Username,
-			Nickname:  invitee.Nick,
-			GuildID:   invitee.GuildID,
-			InvitedBy: invitee.User.ID,
-		}); err != nil {
-			h.log.Fields(logger.Fields{"inviteeID": invitee.User.ID, "inviteeUsrName": invitee.User.Username, "inviteeNickName": invitee.Nick, "inviteeGuildID": invitee.GuildID}).Error(err, "[handler.handleInviteTracker] - failed to create user")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		}
-		response.InviteeID = invitee.User.ID
-	}
-
-	inviteType := model.INVITE_TYPE_NORMAL
-	if inviter == nil {
-		inviteType = model.INVITE_TYPE_LEFT
-	}
-
-	// TODO: Can't find age of user now
-	// if time.Now().Unix()-invit < 60*60*24*3 {
-	// 	inviteType = model.INVITE_TYPE_FAKE
-	// }
-
-	if err := h.entities.CreateInviteHistory(request.CreateInviteHistoryRequest{
-		GuildID: invitee.GuildID,
-		Inviter: inviter.User.ID,
-		Invitee: invitee.User.ID,
-		Type:    inviteType,
-	}); err != nil {
-		h.log.Fields(logger.Fields{"inviteeID": invitee.User.ID, "inviterID": invitee.User.ID, "inviteType": inviteType, "inviteeGuildID": invitee.GuildID}).Error(err, "[handler.handleInviteTracker] - failed to create invite history")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	totalInvites, err := h.entities.CountInviteHistoriesByGuildUser(inviter.GuildID, inviter.User.ID)
-	if err != nil {
-		h.log.Fields(logger.Fields{"inviterID": invitee.User.ID, "inviterGuildID": inviter.GuildID}).Error(err, "[handler.handleInviteTracker] - failed to count inviter invites")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	response.InvitesAmount = int(totalInvites)
 	c.JSON(http.StatusOK, gin.H{
 		"data": response,
 	})

--- a/pkg/repo/guild_users/pg.go
+++ b/pkg/repo/guild_users/pg.go
@@ -31,3 +31,7 @@ func (pg *pg) GetGuildUsers(guildID string) ([]model.GuildUser, error) {
 	var result []model.GuildUser
 	return result, pg.db.Where("guild_id = ?", guildID).Find(&result).Error
 }
+
+func (pg *pg) Create(guildUser *model.GuildUser) error {
+	return pg.db.Create(guildUser).Error
+}

--- a/pkg/repo/guild_users/store.go
+++ b/pkg/repo/guild_users/store.go
@@ -7,4 +7,5 @@ type Store interface {
 	Update(guildId, userId string, field string, value interface{}) error
 	CountByGuildUser(guildId, userId string) (int64, error)
 	FirstOrCreate(guildUser *model.GuildUser) error
+	Create(guildUser *model.GuildUser) error
 }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix: invite tracker auto remove user address
-   [x] Move logic from handler to entities

**Bug**

When new user join server, event `guildMemberAdd` will be triggered and backend create user for both inviter and invitee. It make a bug and remove wallet address + wallet number if user exists in the database.

**Flow**

`HandleInviteTracker` flow:

![image](https://user-images.githubusercontent.com/104887632/187182749-5c398a42-0285-49ea-b242-850e2f8d95ed.png)

