### PR TITLE
fix: send wrong gm streak log

### DIFF
--- a/pkg/entities/webhook.go
+++ b/pkg/entities/webhook.go
@@ -262,7 +262,11 @@ func (e *Entity) newUserGM(authorAvatar, authorUsername, discordID, guildID, cha
 	}
 
 	// send message to log channel
-	_ = e.svc.Discord.NotifyGmStreak(discordID, streak.StreakCount, *podTownXps)
+	guild, err := e.repo.DiscordGuilds.GetByID(guildID)
+	if err != nil {
+		return nil, err
+	}
+	_ = e.svc.Discord.NotifyGmStreak(guild.LogChannel, discordID, streak.StreakCount, *podTownXps)
 	return res, e.replyGmGn(streak, channelID, discordID, authorAvatar, authorUsername, "", true)
 }
 

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -99,7 +99,7 @@ func (d *Discord) NotifyAddNewCollection(guildID string, collectionName string, 
 	return nil
 }
 
-func (d *Discord) NotifyGmStreak(userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error {
+func (d *Discord) NotifyGmStreak(channelID string, userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error {
 	color, _ := strconv.ParseInt("6FC1D1", 16, 64)
 	approveIcon := ""
 	if streakCount <= 100 {
@@ -130,7 +130,7 @@ func (d *Discord) NotifyGmStreak(userDiscordID string, streakCount int, podTownX
 		Timestamp: time.Now().Format("2006-01-02T15:04:05Z07:00"),
 	}
 
-	_, err := d.session.ChannelMessageSendEmbed(d.mochiLogChannelID, &msgEmbed)
+	_, err := d.session.ChannelMessageSendEmbed(channelID, &msgEmbed)
 	if err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -50,17 +50,17 @@ func (mr *MockServiceMockRecorder) NotifyAddNewCollection(guildID, collectionNam
 }
 
 // NotifyGmStreak mocks base method.
-func (m *MockService) NotifyGmStreak(userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error {
+func (m *MockService) NotifyGmStreak(channelID, userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NotifyGmStreak", userDiscordID, streakCount, podTownXps)
+	ret := m.ctrl.Call(m, "NotifyGmStreak", channelID, userDiscordID, streakCount, podTownXps)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // NotifyGmStreak indicates an expected call of NotifyGmStreak.
-func (mr *MockServiceMockRecorder) NotifyGmStreak(userDiscordID, streakCount, podTownXps interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) NotifyGmStreak(channelID, userDiscordID, streakCount, podTownXps interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyGmStreak", reflect.TypeOf((*MockService)(nil).NotifyGmStreak), userDiscordID, streakCount, podTownXps)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyGmStreak", reflect.TypeOf((*MockService)(nil).NotifyGmStreak), channelID, userDiscordID, streakCount, podTownXps)
 }
 
 // NotifyNewGuild mocks base method.

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -15,5 +15,5 @@ type Service interface {
 	SendUpdateRolesLog(guildID, logChannelID, userID, roleID, _type string) error
 	SendGuildActivityLogs(channelID, userID, title, description string) error
 	SendLevelUpMessage(logChannelID, role string, uActivity *response.HandleUserActivityResponse)
-	NotifyGmStreak(userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error
+	NotifyGmStreak(channelID string, userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error
 }


### PR DESCRIPTION
GM streak send log message wrong:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/39881166/187334498-5235a104-6716-4649-8498-3df01f149329.png">
- old: send to mochi_log_channel_id which is bot-logs in server Mochi
- new: send to log_channel per server (column log_channel in table discord_guilds)