### PR TITLE
refactor: upsert users

### DIFF
--- a/dbconfig.yml
+++ b/dbconfig.yml
@@ -18,6 +18,6 @@ prod:
 
 test:
   dialect: postgres
-  datasource: host=localhost port=25432 user=postgres password=postgres dbname=mochi_local_test sslmode=disable
+  datasource: host=localhost port=25433 user=postgres password=postgres dbname=mochi_local_test sslmode=disable
   dir: migrations/schemas
   table: migrations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,6 @@ services:
       POSTGRES_PASSWORD: postgres
     container_name: mochi_local_test
     ports:
-      - 25432:5432
+      - 25433:5432
     expose:
-      - 25432
+      - 25433

--- a/migrations/schemas/20220829174242-remove-activity_logs_users_fkey.sql
+++ b/migrations/schemas/20220829174242-remove-activity_logs_users_fkey.sql
@@ -1,0 +1,6 @@
+
+-- +migrate Up
+ALTER TABLE guild_user_activity_logs DROP CONSTRAINT IF EXISTS guild_user_activity_xps_user_id_fkey;
+
+-- +migrate Down
+ALTER TABLE guild_user_activity_logs ADD CONSTRAINT guild_user_activity_xps_user_id_fkey FOREIGN KEY(user_id) REFERENCES users(id);

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,7 +203,7 @@ func LoadTestConfig() Config {
 		DBUser: "postgres",
 		DBPass: "postgres",
 		DBHost: "localhost",
-		DBPort: "25432",
+		DBPort: "25433",
 		DBName: "mochi_local_test",
 
 		InDiscordWalletMnemonic: "holiday frequent toy bachelor auto use style result recycle crumble glue blouse",

--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -35,6 +35,7 @@ func (e *Entity) UpsertGmConfig(req request.UpsertGmConfigRequest) error {
 
 	return nil
 }
+
 func (e *Entity) GetSalesTrackerConfig(guildID string) (*model.GuildConfigSalesTracker, error) {
 	config, err := e.repo.GuildConfigSalesTracker.GetByGuildID(guildID)
 	if err != nil {
@@ -43,6 +44,7 @@ func (e *Entity) GetSalesTrackerConfig(guildID string) (*model.GuildConfigSalesT
 
 	return config, nil
 }
+
 func (e *Entity) UpsertSalesTrackerConfig(req request.UpsertSalesTrackerConfigRequest) error {
 	tmp := &model.GuildConfigSalesTracker{
 		GuildID:   req.GuildID,
@@ -54,28 +56,27 @@ func (e *Entity) UpsertSalesTrackerConfig(req request.UpsertSalesTrackerConfigRe
 	}
 	return nil
 }
+
 func (e *Entity) GetGuildTokens(guildID string) ([]model.Token, error) {
 	if guildID == "" {
-		tokens, err := e.repo.Token.GetDefaultTokens()
-		if err != nil {
-			e.log.Error(err, "[Entity][GetGuildTokens] repo.Token.GetDefaultTokens failed")
-			return nil, err
-		}
-		return tokens, nil
+		return e.repo.Token.GetDefaultTokens()
 	}
 
-	guildTokens, err := e.repo.GuildConfigToken.GetByGuildID(guildID)
+	gTokens, err := e.repo.GuildConfigToken.GetByGuildID(guildID)
 	if err != nil {
 		e.log.Error(err, "[Entity][GetGuildTokens] repo.GuildConfigToken.GetByGuildID failed")
 		return nil, err
 	}
-
-	var data []model.Token
-	for _, gToken := range guildTokens {
-		data = append(data, *gToken.Token)
+	// get tokens with guild_default = TRUE
+	if len(gTokens) == 0 {
+		return e.repo.Token.GetDefaultTokens()
 	}
 
-	return data, nil
+	var tokens []model.Token
+	for _, gToken := range gTokens {
+		tokens = append(tokens, *gToken.Token)
+	}
+	return tokens, nil
 }
 
 func (e *Entity) UpsertGuildTokenConfig(req request.UpsertGuildTokenConfigRequest) error {

--- a/pkg/entities/webhook.go
+++ b/pkg/entities/webhook.go
@@ -139,20 +139,8 @@ func (e *Entity) HandleDiscordMessage(message *discordgo.Message) (*response.Han
 		guildID        = message.GuildID
 		sentAt         = message.Timestamp
 		channelID      = message.ChannelID
+		isGmMessage    = message.Content == "gm" || message.Content == "gn"
 	)
-
-	// message.Content == "" is default message when new user join server
-	if message.Content == "" {
-		return nil, nil
-	}
-	if err := e.CreateUserIfNotExists(discordID, authorUsername); err != nil {
-		e.log.Fields(logger.Fields{"userID": discordID, "username": authorUsername}).Error(err, "[Entity][HandleDiscordMessage] failed to create user")
-	}
-	if err := e.CreateGuildUserIfNotExists(guildID, discordID, ""); err != nil {
-		e.log.Fields(logger.Fields{"userID": discordID, "guildID": guildID}).Error(err, "[Entity][HandleDiscordMessage] failed to create guild user")
-	}
-
-	isGmMessage := message.Content == "gm" || message.Content == "gn"
 
 	switch {
 	case isGmMessage:

--- a/pkg/handler/guilds.go
+++ b/pkg/handler/guilds.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -190,8 +189,6 @@ func (h *Handler) UpdateGuild(c *gin.Context) {
 		omit = "global_xp"
 	}
 	globalXP := strings.EqualFold(req.GlobalXP, "true")
-	fmt.Println(omit, globalXP, req)
-
 	if err := h.entities.UpdateGuild(omit, guildID, globalXP, req.LogChannel); err != nil {
 		h.log.Fields(logger.Fields{"guildID": guildID, "globalXP": req.GlobalXP, "logChannel": req.LogChannel}).Error(err, "[handler.UpdateGuild] - failed to update guild")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err})

--- a/pkg/job/fetch_discord_users.go
+++ b/pkg/job/fetch_discord_users.go
@@ -52,7 +52,7 @@ func (j *fetchDiscordUsers) Run() error {
 
 	// create users
 	for _, req := range createUserRequests {
-		if err := j.entity.CreateUserIfNotExists(req.ID, req.Username); err != nil {
+		if _, err := j.entity.GetOneOrUpsertUser(req.ID); err != nil {
 			j.log.Fields(logger.Fields{"user": req}).Error(err, "failed to create user")
 			continue
 		}

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -1,10 +1,5 @@
 package model
 
-import (
-	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
-)
-
 type User struct {
 	ID                     string         `json:"id" gorm:"primary_key"`
 	Username               string         `json:"username"`
@@ -12,16 +7,4 @@ type User struct {
 	InDiscordWalletNumber  JSONNullInt64  `json:"in_discord_wallet_number"`
 
 	GuildUsers []*GuildUser `json:"guild_users"`
-}
-
-func (u *User) BeforeCreate(tx *gorm.DB) (err error) {
-	cols := []clause.Column{}
-	for _, field := range tx.Statement.Schema.PrimaryFields {
-		cols = append(cols, clause.Column{Name: field.DBName})
-	}
-	tx.Statement.AddClause(clause.OnConflict{
-		Columns:   cols,
-		DoUpdates: clause.AssignmentColumns([]string{"in_discord_wallet_number", "in_discord_wallet_address"}),
-	})
-	return nil
 }

--- a/pkg/repo/users/store.go
+++ b/pkg/repo/users/store.go
@@ -3,11 +3,8 @@ package users
 import "github.com/defipod/mochi/pkg/model"
 
 type Store interface {
-	Create(user *model.User) error
-	FirstOrCreate(user *model.User) error
-
+	Upsert(user *model.User) error
 	GetLatestWalletNumber() int
 	GetOne(discordID string) (*model.User, error)
 	GetByDiscordIDs(discordIDs []string) ([]model.User, error)
-	Update(u *model.User) error
 }

--- a/pkg/util/testhelper/db.go
+++ b/pkg/util/testhelper/db.go
@@ -25,7 +25,7 @@ func LoadTestDB(seedPath string) *gorm.DB {
 		// initiate logger
 		l := logger.NewLogrusLogger()
 
-		conn, err = sql.Open("postgres", "host=localhost port=25432 user=postgres password=postgres dbname=mochi_local_test sslmode=disable")
+		conn, err = sql.Open("postgres", "host=localhost port=25433 user=postgres password=postgres dbname=mochi_local_test sslmode=disable")
 		if err != nil {
 			l.Fatalf(err, "failed to open database connection")
 			return


### PR DESCRIPTION
**What does this PR do?**
- [x] Fixed user's activities error: if a user not found in table `users` (may due to job not run yet), then his/her activities won't be logged (because FK constraint between `guild_user_activity_logs` and `users`)
-> remove FK
- [x] Remove hook `BeforeCreate` of model `User`
- [x] Store: remove `Update()` / `Create()` -> use `Upsert()` instead
- [x] Entity: remove `CreateUserIfNotExists()` -> use `GetOneOrUpsertUser()` instead

Flow `GetOneOrUpsertUser()`:
1. User not exists -> create new
2. Already existed but no wallet -> generate wallet
3. Already existed but discord username updated -> update user

**PS: sorry for not providing any diagram**