### PR TITLE
chore: cleanup discord alerts

### DIFF
--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -209,14 +209,6 @@ func (e *Entity) GetUserRoleByLevel(guildID string, level int) (string, error) {
 	return config.RoleID, nil
 }
 
-func (e *Entity) AddGuildMemberRole(guildID, userID, roleID string) error {
-	return e.discord.GuildMemberRoleAdd(guildID, userID, roleID)
-}
-
-func (e *Entity) RemoveGuildMemberRole(guildID, userID, roleID string) error {
-	return e.discord.GuildMemberRoleRemove(guildID, userID, roleID)
-}
-
 func (e *Entity) ListGuildNFTRoleConfigs(guildID string) ([]model.GuildConfigGroupNFTRole, error) {
 	return e.repo.GuildConfigGroupNFTRole.ListByGuildID(guildID)
 }

--- a/pkg/entities/discord.go
+++ b/pkg/entities/discord.go
@@ -358,3 +358,11 @@ func (e *Entity) GetGuildById(guildID string) (*discordgo.Guild, error) {
 	}
 	return guild, nil
 }
+
+func (e *Entity) AddGuildMemberRole(guildID, userID, roleID string) error {
+	return e.discord.GuildMemberRoleAdd(guildID, userID, roleID)
+}
+
+func (e *Entity) RemoveGuildMemberRole(guildID, userID, roleID string) error {
+	return e.discord.GuildMemberRoleRemove(guildID, userID, roleID)
+}

--- a/pkg/entities/entity.go
+++ b/pkg/entities/entity.go
@@ -19,6 +19,7 @@ import (
 	"github.com/defipod/mochi/pkg/service/abi"
 	"github.com/defipod/mochi/pkg/service/indexer"
 	"github.com/defipod/mochi/pkg/service/marketplace"
+	"github.com/defipod/mochi/pkg/util"
 )
 
 var (
@@ -142,10 +143,14 @@ func (e *Entity) initInviteTrackerCache() error {
 		if guild == nil {
 			continue
 		}
-		// logic invite reacker cache
+		// logic invite tracker cache
 		invites, err := e.discord.GuildInvites(guild.ID)
+		if util.IsAcceptableErr(err) {
+			e.log.Fields(logger.Fields{"guild_id": guild.ID}).Infof("[entity.initInviteTrackerCache] discord.GuildInvites failed: %v", err)
+			return nil
+		}
 		if err != nil {
-			return fmt.Errorf("failed to get invites for guild %s: %w", guild.ID, err)
+			return fmt.Errorf("failed to get invites for guild %s: %v", guild.ID, err)
 		}
 
 		invitesUses := make(map[string]string)

--- a/pkg/entities/user.go
+++ b/pkg/entities/user.go
@@ -235,24 +235,19 @@ func (e *Entity) GetGuildMember(guildID, userID string) (*discordgo.Member, erro
 }
 
 func (e *Entity) ListGuildMembers(guildID string) ([]*discordgo.Member, error) {
-
 	var afterID string
-
 	res := make([]*discordgo.Member, 0)
 	for {
 		members, err := e.discord.GuildMembers(guildID, afterID, 100)
 		if err != nil {
 			return nil, err
 		}
-
 		res = append(res, members...)
-
 		if len(members) < 100 {
 			break
 		}
 		afterID = members[len(members)-1].User.ID
 	}
-
 	return res, nil
 }
 

--- a/pkg/handler/default_roles.go
+++ b/pkg/handler/default_roles.go
@@ -23,6 +23,7 @@ func (h *Handler) GetDefaultRolesByGuildID(c *gin.Context) {
 	if !isExist {
 		h.log.Info("[handler.GetDefaultRolesByGuildID] - guild id empty")
 		c.JSON(http.StatusBadRequest, gin.H{"error": "guild_id is required"})
+		return
 	}
 
 	data, err := h.entities.GetDefaultRoleByGuildID(guildID)
@@ -84,6 +85,7 @@ func (h *Handler) DeleteDefaultRoleByGuildID(c *gin.Context) {
 	if !isExist {
 		h.log.Info("[handler.DeleteDefaultRoleByGuildID] - guild id empty")
 		c.JSON(http.StatusBadRequest, gin.H{"error": "guild_id is required"})
+		return
 	}
 	err := h.entities.DeleteDefaultRoleConfig(guildID)
 	if err != nil {

--- a/pkg/job/update_user_roles.go
+++ b/pkg/job/update_user_roles.go
@@ -5,6 +5,7 @@ import (
 	"github.com/defipod/mochi/pkg/logger"
 	"github.com/defipod/mochi/pkg/model"
 	"github.com/defipod/mochi/pkg/service"
+	"github.com/defipod/mochi/pkg/util"
 	"gorm.io/gorm"
 )
 
@@ -30,13 +31,20 @@ func (job *updateUserRoles) Run() error {
 	}
 
 	for _, guild := range guilds.Data {
-		err = job.updateLevelRoles(guild.ID)
+		_, err := job.entity.GetGuildById(guild.ID)
+		if util.IsAcceptableErr(err) {
+			job.log.Fields(logger.Fields{"guildId": guild.ID}).Infof("entity.GetGuildById - bot has no permission or access to this guild: %v", err)
+			continue
+		}
 		if err != nil {
+			job.log.Fields(logger.Fields{"guildId": guild.ID}).Error(err, "entity.GetGuildById failed")
+			continue
+		}
+		if err := job.updateLevelRoles(guild.ID); err != nil {
 			job.log.Fields(logger.Fields{"guildId": guild.ID}).Error(err, "Run failed")
 		}
 
-		err = job.updateNFTRoles(guild.ID)
-		if err != nil {
+		if err := job.updateNFTRoles(guild.ID); err != nil {
 			job.log.Fields(logger.Fields{"guildId": guild.ID}).Error(err, "Run failed")
 		}
 	}
@@ -78,6 +86,13 @@ func (job *updateUserRoles) updateLevelRoles(guildID string) error {
 	rolesToRemove := make(map[string]string)
 	for _, userXP := range userXPs {
 		member, err := job.entity.GetGuildMember(guildID, userXP.UserID)
+		if util.IsAcceptableErr(err) {
+			job.log.Fields(logger.Fields{
+				"userId":  userXP.UserID,
+				"guildId": guildID,
+			}).Info("[updateLevelRoles] user is no longer guild member")
+			continue
+		}
 		if err != nil {
 			job.log.Fields(logger.Fields{
 				"userId":  userXP.UserID,
@@ -120,7 +135,16 @@ func (job *updateUserRoles) updateLevelRoles(guildID string) error {
 	}
 
 	for userID, roleID := range rolesToRemove {
-		if err := job.entity.RemoveGuildMemberRole(guildID, userID, roleID); err != nil {
+		err := job.entity.RemoveGuildMemberRole(guildID, userID, roleID)
+		if util.IsAcceptableErr(err) {
+			job.log.Fields(logger.Fields{
+				"guildId": guildID,
+				"userId":  userID,
+				"roleId":  roleID,
+			}).Infof("[updateLevelRoles] entity.RemoveGuildMemberRole failed: %v", err)
+			continue
+		}
+		if err != nil {
 			job.log.Fields(logger.Fields{
 				"guildId": guildID,
 				"userId":  userID,
@@ -136,7 +160,16 @@ func (job *updateUserRoles) updateLevelRoles(guildID string) error {
 	}
 
 	for userID, roleID := range rolesToAdd {
-		if err := job.entity.AddGuildMemberRole(guildID, userID, roleID); err != nil {
+		err := job.entity.AddGuildMemberRole(guildID, userID, roleID)
+		if util.IsAcceptableErr(err) {
+			job.log.Fields(logger.Fields{
+				"guildId": guildID,
+				"userId":  userID,
+				"roleId":  roleID,
+			}).Infof("[updateLevelRoles] entity.AddGuildMemberRole failed: %v", err)
+			continue
+		}
+		if err != nil {
 			job.log.Fields(logger.Fields{
 				"guildId": guildID,
 				"userId":  userID,
@@ -151,7 +184,7 @@ func (job *updateUserRoles) updateLevelRoles(guildID string) error {
 		}).Info("[updateLevelRoles] entity.AddGuildMemberRole executed successfully")
 
 		// send logs to moderation channel
-		err := job.service.Discord.SendUpdateRolesLog(guildID, guild.LogChannel, userID, roleID, "level-role")
+		err = job.service.Discord.SendUpdateRolesLog(guildID, guild.LogChannel, userID, roleID, "level-role")
 		if err != nil {
 			job.log.Fields(logger.Fields{
 				"guildId":   guildID,
@@ -216,6 +249,10 @@ func (job *updateUserRoles) updateNFTRoles(guildID string) error {
 					"roleId":  roleID,
 				})
 				err = job.entity.RemoveGuildMemberRole(guildID, member.User.ID, roleID)
+				if util.IsAcceptableErr(err) {
+					gMemberRoleLog.Infof("[updateNFTRoles] entity.RemoveGuildMemberRole failed: %v", err)
+					continue
+				}
 				if err != nil {
 					gMemberRoleLog.Error(err, "[updateNFTRoles] entity.RemoveGuildMemberRole failed")
 					continue
@@ -240,6 +277,10 @@ func (job *updateUserRoles) updateNFTRoles(guildID string) error {
 			"roleId":  roleID,
 		})
 		err = job.entity.AddGuildMemberRole(guildID, userID, roleID)
+		if util.IsAcceptableErr(err) {
+			gMemberRoleLog.Infof("[updateNFTRoles] entity.AddGuildMemberRole failed: %v", err)
+			continue
+		}
 		if err != nil {
 			gMemberRoleLog.Error(err, "[updateNFTRoles] entity.AddGuildMemberRole failed")
 			continue

--- a/pkg/util/discord.go
+++ b/pkg/util/discord.go
@@ -1,0 +1,23 @@
+package util
+
+import "strings"
+
+func isMissingPermissionsErr(msg string) bool {
+	return strings.Contains(msg, "missing permissions") && strings.Contains(msg, "50013")
+}
+
+func isMissingAccessErr(msg string) bool {
+	return strings.Contains(msg, "missing access") && strings.Contains(msg, "50001")
+}
+
+func isMemberNotFoundErr(msg string) bool {
+	return strings.Contains(msg, "404 not found") && strings.Contains(msg, "10007")
+}
+
+func IsAcceptableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return isMissingPermissionsErr(msg) || isMissingAccessErr(msg) || isMemberNotFoundErr(msg)
+}


### PR DESCRIPTION
**What does this PR do?**
Clean up discord alerts - Do not send to Mochi's alert channel when error is one of these types
- [x] Missing Permissions (403) -> Mochi has not been granted necessary permissions
- [x] Missing Access (403) -> Mochi was kicked from guild
- [x] Unknown Member / Not Found (404) -> User is no longer a guild member (left guild)