### PR TITLE
fix: allow equal nft config

### DIFF
--- a/pkg/repo/user_nft_balance/pg.go
+++ b/pkg/repo/user_nft_balance/pg.go
@@ -73,7 +73,7 @@ func (pg *pg) GetUserNFTBalancesByUserInGuild(guildID string) ([]model.MemberNFT
 				role_id,
 				number_of_tokens) AS temp
 	WHERE
-		temp.total_balance > temp.number_of_tokens
+		temp.total_balance >= temp.number_of_tokens
 	ORDER BY
 		temp.user_discord_id,
 		temp.number_of_tokens DESC;


### PR DESCRIPTION
Config `Not a Pod Gang` requires 0 NFT
Config `Podians` requires 1 NFT
User has 1 NFT

- Old: assign role `Not a Pod Gang`
- New: assign role `Podians`