### PR TITLE
fix: solana contract name

### DIFF
--- a/pkg/entities/nfts.go
+++ b/pkg/entities/nfts.go
@@ -310,8 +310,8 @@ func (e *Entity) CreateSolanaNFTCollection(req request.CreateNFTCollectionReques
 
 	nftCollection, err = e.repo.NFTCollection.Create(model.NFTCollection{
 		Address:    req.Address,
-		Symbol:     solanaCollection.OffChainData.Symbol,
-		Name:       solanaCollection.OffChainData.Name,
+		Symbol:     solanaCollection.Data.Symbol,
+		Name:       solanaCollection.Data.Name,
 		ChainID:    "0",
 		ERCFormat:  "ERC721",
 		IsVerified: true,
@@ -323,7 +323,7 @@ func (e *Entity) CreateSolanaNFTCollection(req request.CreateNFTCollectionReques
 		return nil, fmt.Errorf("Cannot add collection: %v", err)
 	}
 
-	err = e.svc.Discord.NotifyAddNewCollection(req.GuildID, solanaCollection.OffChainData.Name, solanaCollection.OffChainData.Symbol, util.ConvertChainIDToChain("sol"), solanaCollection.OffChainData.Image)
+	err = e.svc.Discord.NotifyAddNewCollection(req.GuildID, solanaCollection.Data.Name, solanaCollection.Data.Symbol, util.ConvertChainIDToChain("sol"), solanaCollection.OffChainData.Image)
 	if err != nil {
 		e.log.Errorf(err, "[e.svc.Discord.NotifyAddNewCollection] cannot send embed message: %v", err)
 		return nil, fmt.Errorf("Cannot send embed message: %v", err)

--- a/pkg/model/solana.go
+++ b/pkg/model/solana.go
@@ -2,10 +2,16 @@ package model
 
 type SolanaCollectionMetadata struct {
 	OffChainData SolanaOffchainData `json:"off_chain_data"`
+	Data         SolanaData         `json:"data"`
 }
 
 type SolanaOffchainData struct {
 	Image  string `json:"image"`
+	Name   string `json:"name"`
+	Symbol string `json:"symbol"`
+}
+
+type SolanaData struct {
 	Name   string `json:"name"`
 	Symbol string `json:"symbol"`
 }


### PR DESCRIPTION
- Old: Get data on `off_chain_data` field, this is sometimes empty
- New: Get data in `data` field of Solana API, this always has data