### PR TITLE
chore: add explorer url to nft role

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6254,6 +6254,9 @@ const docTemplate = `{
                 "chain_id": {
                     "type": "string"
                 },
+                "chain_name": {
+                    "type": "string"
+                },
                 "collection_id": {
                     "type": "string"
                 },
@@ -6261,6 +6264,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "erc_format": {
+                    "type": "string"
+                },
+                "explorer_url": {
                     "type": "string"
                 },
                 "id": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6246,6 +6246,9 @@
                 "chain_id": {
                     "type": "string"
                 },
+                "chain_name": {
+                    "type": "string"
+                },
                 "collection_id": {
                     "type": "string"
                 },
@@ -6253,6 +6256,9 @@
                     "type": "string"
                 },
                 "erc_format": {
+                    "type": "string"
+                },
+                "explorer_url": {
                     "type": "string"
                 },
                 "id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1660,11 +1660,15 @@ definitions:
         type: string
       chain_id:
         type: string
+      chain_name:
+        type: string
       collection_id:
         type: string
       created_at:
         type: string
       erc_format:
+        type: string
+      explorer_url:
         type: string
       id:
         type: string

--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -416,6 +416,8 @@ func (e *Entity) ListGuildGroupNFTRoles(guildID string) ([]response.ListGuildNFT
 				ID:           role.ID.UUID.String(),
 				CollectionID: collection.ID.UUID.String(),
 				Address:      collection.Address,
+				ExplorerUrl:  util.GetCollectionExplorerUrl(collection.Address, collection.ChainID),
+				ChainName:    util.ConvertChainIDToChain(collection.ChainID),
 				Name:         collection.Name,
 				Symbol:       collection.Symbol,
 				ChainID:      collection.ChainID,

--- a/pkg/response/config.go
+++ b/pkg/response/config.go
@@ -78,6 +78,8 @@ type NFTCollectionConfig struct {
 	ID           string    `json:"id"`
 	CollectionID string    `json:"collection_id"`
 	Address      string    `json:"address"`
+	ExplorerUrl  string    `json:"explorer_url"`
+	ChainName    string    `json:"chain_name"`
 	Name         string    `json:"name"`
 	Symbol       string    `json:"symbol"`
 	ChainID      string    `json:"chain_id"`

--- a/pkg/util/marketplace.go
+++ b/pkg/util/marketplace.go
@@ -56,6 +56,21 @@ func GetWalletUrl(marketplace string) (urlMarketPlace string) {
 	}
 }
 
+func GetCollectionExplorerUrl(address string, chainID string) string {
+	switch chainID {
+	case "1":
+		return "https://etherscan.io/address/" + address
+	case "250":
+		return "https://ftmscan.com/address/" + address
+	case "10":
+		return "https://optimistic.etherscan.io/address/" + address
+	case "56":
+		return "https://bscscan.com/address/" + address
+	default:
+		return ""
+	}
+}
+
 func GetGainEmoji(gain *big.Float) string {
 	cmp := gain.Cmp(big.NewFloat(0))
 	if cmp == 1 {


### PR DESCRIPTION
- Add `explorer_link` and `chain_name` to api list nft-roles
```
"chain_name": "eth",
"explorer_url": "https://etherscan.io/address/0x7D1070fdbF0eF8752a9627a79b00221b53F231fA"
```
<img width="1508" alt="image" src="https://user-images.githubusercontent.com/39881166/189826956-1b278b84-f9c8-4e1b-905e-19fd52dc72b2.png">
