### PR TITLE
chore: cache upvote msg

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -82,6 +82,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/cache/upvote": {
+            "post": {
+                "description": "Set or overwrite an upvote message cache",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cache"
+                ],
+                "summary": "Set or overwrite an upvote message cache",
+                "parameters": [
+                    {
+                        "description": "Set upvote message cache request",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.SetUpvoteMessageCacheRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseMessage"
+                        }
+                    }
+                }
+            }
+        },
         "/chains": {
             "get": {
                 "description": "List All Chain",
@@ -2408,7 +2442,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": ""
+                        "description": "No Content"
                     }
                 }
             }
@@ -3647,7 +3681,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "OK"
                     }
                 }
             }
@@ -4842,6 +4876,23 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "role_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.SetUpvoteMessageCacheRequest": {
+            "type": "object",
+            "properties": {
+                "channel_id": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "message_id": {
+                    "type": "string"
+                },
+                "user_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -74,6 +74,40 @@
                 }
             }
         },
+        "/cache/upvote": {
+            "post": {
+                "description": "Set or overwrite an upvote message cache",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cache"
+                ],
+                "summary": "Set or overwrite an upvote message cache",
+                "parameters": [
+                    {
+                        "description": "Set upvote message cache request",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.SetUpvoteMessageCacheRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseMessage"
+                        }
+                    }
+                }
+            }
+        },
         "/chains": {
             "get": {
                 "description": "List All Chain",
@@ -2400,7 +2434,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": ""
+                        "description": "No Content"
                     }
                 }
             }
@@ -3639,7 +3673,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "OK"
                     }
                 }
             }
@@ -4834,6 +4868,23 @@
                     "type": "string"
                 },
                 "role_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.SetUpvoteMessageCacheRequest": {
+            "type": "object",
+            "properties": {
+                "channel_id": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "message_id": {
+                    "type": "string"
+                },
+                "user_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -750,6 +750,17 @@ definitions:
       role_id:
         type: string
     type: object
+  request.SetUpvoteMessageCacheRequest:
+    properties:
+      channel_id:
+        type: string
+      guild_id:
+        type: string
+      message_id:
+        type: string
+      user_id:
+        type: string
+    type: object
   request.TransferRequest:
     properties:
       all:
@@ -2028,6 +2039,28 @@ paths:
       summary: Logout
       tags:
       - Auth
+  /cache/upvote:
+    post:
+      consumes:
+      - application/json
+      description: Set or overwrite an upvote message cache
+      parameters:
+      - description: Set upvote message cache request
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/request.SetUpvoteMessageCacheRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.ResponseMessage'
+      summary: Set or overwrite an upvote message cache
+      tags:
+      - Cache
   /chains:
     get:
       consumes:
@@ -3460,7 +3493,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: ""
+          description: No Content
       summary: Delete custom commands
       tags:
       - Custom Command
@@ -4422,7 +4455,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: ""
+          description: OK
       summary: Get whitelist campaign users csv
       tags:
       - Whitelist campaign

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/defipod/mochi
 go 1.17
 
 require (
-	github.com/bwmarrin/discordgo v0.25.0
+	github.com/bwmarrin/discordgo v0.26.1
 	github.com/ethereum/go-ethereum v1.10.17
 	github.com/ewohltman/discordgo-mock v0.0.6
 	github.com/gin-contrib/cors v1.3.1
@@ -36,7 +36,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330 // indirect
 	github.com/chai2010/webp v1.1.1 // indirect
-	github.com/disintegration/imaging v1.6.2 // indirect
+	github.com/disintegration/imaging v1.6.2
 	github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc // indirect
 	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
 	github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17 // indirect
@@ -44,7 +44,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
-	github.com/go-testfixtures/testfixtures/v3 v3.8.1 // indirect
+	github.com/go-testfixtures/testfixtures/v3 v3.8.1
 	github.com/goccy/go-json v0.9.7 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
@@ -56,16 +56,16 @@ require (
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
-	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a // indirect
-	github.com/swaggo/gin-swagger v1.5.2 // indirect
-	github.com/swaggo/swag v1.8.1 // indirect
+	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a
+	github.com/swaggo/gin-swagger v1.5.2
+	github.com/swaggo/swag v1.8.1
 	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
+	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
 	golang.org/x/tools v0.1.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
-	google.golang.org/api v0.85.0 // indirect
+	google.golang.org/api v0.85.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad // indirect
 	google.golang.org/grpc v1.47.0 // indirect
@@ -84,20 +84,11 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
-	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.19.6 // indirect
-	github.com/go-openapi/spec v0.20.4 // indirect
-	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/goccy/go-json v0.9.7 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
-	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -111,17 +102,14 @@ require (
 	github.com/jackc/pgx/v4 v4.16.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.4 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
-	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rjeczalik/notify v0.9.1 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
@@ -135,17 +123,9 @@ require (
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
-	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/mod v0.5.0 // indirect
-	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect
-	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
 	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/tools v0.1.7 // indirect
-	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
-	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad // indirect
-	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
@@ -157,15 +137,4 @@ require (
 	cloud.google.com/go/storage v1.24.0
 	github.com/ChimeraCoder/anaconda v2.0.0+incompatible
 	github.com/ChimeraCoder/tokenbucket v0.0.0-20131201223612-c5a927568de7 // indirect
-	github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330 // indirect
-	github.com/disintegration/imaging v1.6.2
-	github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc // indirect
-	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
-	github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17 // indirect
-	github.com/go-testfixtures/testfixtures/v3 v3.8.1
-	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a
-	github.com/swaggo/gin-swagger v1.5.2
-	github.com/swaggo/swag v1.8.1
-	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
-	google.golang.org/api v0.85.0
 )

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/bwmarrin/discordgo v0.24.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/bwmarrin/discordgo v0.25.0 h1:NXhdfHRNxtwso6FPdzW2i3uBvvU7UIQTghmV2T4nqAs=
 github.com/bwmarrin/discordgo v0.25.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
+github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -172,6 +174,7 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chai2010/webp v1.1.1/go.mod h1:0XVwvZWdjjdxpUEIf7b9g9VkHFnInUSYujwqTLEuldU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -609,6 +612,7 @@ github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/kolesa-team/go-webp v1.0.1/go.mod h1:oMvdivD6K+Q5qIIkVC2w4k2ZUnI1H+MyP7inwgWq9aA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -955,6 +959,7 @@ golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86h
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -9,6 +9,7 @@ type Cache interface {
 	Type(key string) (string, error)
 
 	Set(key string, value interface{}, expiration time.Duration) error
+	Remove(key string) error
 	GetString(key string) (string, error)
 	GetInt(key string) (int, error)
 	GetBool(key string) (bool, error)

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -55,6 +55,10 @@ func (c *redisCache) Set(key string, value interface{}, expiration time.Duration
 	return c.rdb.Set(context.Background(), key, value, expiration).Err()
 }
 
+func (c *redisCache) Remove(key string) error {
+	return c.rdb.Del(context.Background(), key).Err()
+}
+
 func (c *redisCache) GetString(key string) (string, error) {
 	res, err := c.rdb.Get(context.Background(), key).Result()
 	switch err {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 
 	RedisURL string
 
+	MochiGuildID           string
 	MochiLogChannelID      string
 	MochiSaleChannelID     string
 	MochiActivityChannelID string
@@ -163,6 +164,7 @@ func generateConfigFromViper(v *viper.Viper) Config {
 		InDiscordWalletMnemonic: v.GetString("IN_DISCORD_WALLET_MNEMONIC"),
 		RedisURL:                v.GetString("REDIS_URL"),
 
+		MochiGuildID:           v.GetString("MOCHI_GUILD_ID"),
 		MochiLogChannelID:      v.GetString("MOCHI_LOG_CHANNEL_ID"),
 		MochiSaleChannelID:     v.GetString("MOCHI_SALE_CHANNEL_ID"),
 		MochiActivityChannelID: v.GetString("MOCHI_ACTIVITY_CHANNEL_ID"),

--- a/pkg/entities/cache.go
+++ b/pkg/entities/cache.go
@@ -1,0 +1,60 @@
+package entities
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/defipod/mochi/pkg/logger"
+	"github.com/defipod/mochi/pkg/request"
+	"github.com/defipod/mochi/pkg/response"
+)
+
+func (e *Entity) SetUpvoteMessageCache(req *request.SetUpvoteMessageCacheRequest) error {
+	// "upvote_msg_<userID>": "<messageID>_<channelID>_<guildID>"
+
+	key := fmt.Sprintf("upvote_msg_%s", req.UserID)
+	value := fmt.Sprintf("%s_%s_%s", req.MessageID, req.ChannelID, req.GuildID)
+	err := e.cache.Set(key, value, time.Duration(time.Minute*5))
+	if err != nil {
+		e.log.Fields(logger.Fields{"key": key, "value": value}).Errorf(err, "[e.SetUpvoteMessageCache] failed to set cache")
+		return err
+	}
+	return nil
+}
+
+func (e *Entity) GetUpvoteMessageCache(userID string) (*response.SetUpvoteMessageCacheResponse, error) {
+	key := fmt.Sprintf("upvote_msg_%s", userID)
+	data, err := e.cache.GetString(key)
+	if err != nil {
+		e.log.Fields(logger.Fields{"key": key, "value": data}).Errorf(err, "[e.GetUpvoteMessageCache] failed to get cache")
+		return nil, err
+	}
+	if data == "" {
+		return nil, nil
+	}
+
+	ids := strings.Split(data, "_")
+	if len(ids) != 3 {
+		err = fmt.Errorf("cached data invalid: %s", data)
+		e.log.Fields(logger.Fields{"key": key, "value": data}).Errorf(err, "[e.GetUpvoteMessageCache] cached data invalid form")
+		return nil, err
+	}
+
+	return &response.SetUpvoteMessageCacheResponse{
+		UserID:    userID,
+		MessageID: ids[0],
+		ChannelID: ids[1],
+		GuildID:   ids[2],
+	}, nil
+}
+
+func (e *Entity) RemoveUpvoteMessageCache(userID string) error {
+	key := fmt.Sprintf("upvote_msg_%s", userID)
+	err := e.cache.Remove(key)
+	if err != nil {
+		e.log.Fields(logger.Fields{"key": key}).Errorf(err, "[e.RemoveUpvoteMessageCache] failed to delete cache")
+		return err
+	}
+	return nil
+}

--- a/pkg/entities/discord.go
+++ b/pkg/entities/discord.go
@@ -336,7 +336,7 @@ func (e *Entity) EditGuildChannel(guildID string, statChannel model.DiscordGuild
 	// }
 
 	newChannelName := util.CreateChannelName(guildStat, statChannel.CountType)
-	_, err = e.discord.ChannelEdit(statChannel.ChannelID, newChannelName)
+	_, err = e.discord.ChannelEdit(statChannel.ChannelID, &discordgo.ChannelEdit{Name: newChannelName})
 	if err != nil {
 		log.Error(err, "failed to edit channel name")
 		return err

--- a/pkg/handler/cache.go
+++ b/pkg/handler/cache.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/defipod/mochi/pkg/logger"
+	"github.com/defipod/mochi/pkg/request"
+	"github.com/defipod/mochi/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// SetUpvoteMessageCache     godoc
+// @Summary     Set or overwrite an upvote message cache
+// @Description Set or overwrite an upvote message cache
+// @Tags        Cache
+// @Accept      json
+// @Produce     json
+// @Param       Request  body request.SetUpvoteMessageCacheRequest true "Set upvote message cache request"
+// @Success     200 {object} response.ResponseMessage
+// @Router      /cache/upvote [post]
+func (h *Handler) SetUpvoteMessageCache(c *gin.Context) {
+	req := request.SetUpvoteMessageCacheRequest{}
+	err := c.BindJSON(&req)
+	if err != nil {
+		h.log.
+			Fields(logger.Fields{"guildID": req.GuildID, "channelID": req.ChannelID, "msgID": req.MessageID, "userID": req.UserID}).
+			Error(err, "[handler.SetUpvoteCache] - failed to read JSON")
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if req.ChannelID == "" || req.GuildID == "" || req.MessageID == "" || req.UserID == "" {
+		h.log.
+			Fields(logger.Fields{"guildID": req.GuildID, "channelID": req.ChannelID, "msgID": req.MessageID, "userID": req.UserID}).
+			Info("[handler.SetUpvoteCache] - missing request fields")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing request fields"})
+		return
+	}
+
+	err = h.entities.SetUpvoteMessageCache(&req)
+	if err != nil {
+		h.log.
+			Fields(logger.Fields{"guildID": req.GuildID, "channelID": req.ChannelID, "msgID": req.MessageID, "userID": req.UserID}).
+			Error(err, "[handler.SetUpvoteCache] - failed to set cache")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, response.ResponseMessage{Message: "ok"})
+}

--- a/pkg/request/cache.go
+++ b/pkg/request/cache.go
@@ -1,0 +1,8 @@
+package request
+
+type SetUpvoteMessageCacheRequest struct {
+	UserID    string `json:"user_id"`
+	GuildID   string `json:"guild_id"`
+	ChannelID string `json:"channel_id"`
+	MessageID string `json:"message_id"`
+}

--- a/pkg/response/cache.go
+++ b/pkg/response/cache.go
@@ -1,0 +1,8 @@
+package response
+
+type SetUpvoteMessageCacheResponse struct {
+	UserID    string `json:"user_id"`
+	GuildID   string `json:"guild_id"`
+	ChannelID string `json:"channel_id"`
+	MessageID string `json:"message_id"`
+}

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -242,4 +242,8 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 	{
 		twitterGroup.POST("", h.CreateTwitterPost)
 	}
+	cacheGroup := v1.Group("/cache")
+	{
+		cacheGroup.POST("/upvote", h.SetUpvoteMessageCache)
+	}
 }

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -2,7 +2,6 @@ package discord
 
 import (
 	"fmt"
-	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +17,7 @@ import (
 type Discord struct {
 	session                *discordgo.Session
 	log                    logger.Logger
+	mochiGuildID           string
 	mochiLogChannelID      string
 	mochiSaleChannelID     string
 	mochiActivityChannelID string
@@ -40,6 +40,7 @@ func NewService(
 	return &Discord{
 		session:                discord,
 		log:                    log,
+		mochiGuildID:           cfg.MochiGuildID,
 		mochiLogChannelID:      cfg.MochiLogChannelID,
 		mochiSaleChannelID:     cfg.MochiSaleChannelID,
 		mochiActivityChannelID: cfg.MochiActivityChannelID,
@@ -286,21 +287,16 @@ func (d *Discord) SendUpdateRolesLog(guildID, logChannelID, userID, roleID, _typ
 	return nil
 }
 
-type upvoteMsg struct {
-	Title       string
-	Description string
-	Image       string
-}
-
 func (d *Discord) SendUpvoteMessage(discordID, source string, isStranger bool) error {
 	if discordID == "" || source == "" {
 		return nil
 	}
 
-	sourceName, sourceUrl := util.UpvoteSourceNameAndUrl(source)
 	voteRemindStr := "\n\nCheck your progress and vote for Mochi with `$vote`"
 	msgEmbed := discordgo.MessageEmbed{}
 	if isStranger {
+		// user can upvote without being in a guild
+		sourceName, sourceUrl := util.UpvoteSourceNameAndUrl(source)
 		msgEmbed = discordgo.MessageEmbed{
 			Title:       "Thank you stranger.",
 			Description: fmt.Sprintf("A mysterious person just upvoted Mochi on [%s](%s). Thank you, whoever you are", sourceName, sourceUrl) + voteRemindStr,
@@ -311,57 +307,14 @@ func (d *Discord) SendUpvoteMessage(discordID, source string, isStranger bool) e
 			},
 		}
 	} else {
-		presets := []upvoteMsg{
-			{
-				Title:       "Mochi appreciates it!",
-				Description: fmt.Sprintf("<@%s> just voted for Mochi on [%s](%s)", discordID, sourceName, sourceUrl),
-				Image:       "https://cdn.discordapp.com/attachments/1003381172178530494/1019165378213068840/unknown.png",
-			},
-			{
-				Title:       "Wait, what?",
-				Description: fmt.Sprintf("<@%s> voted for Mochi, is that all you needed to do to receive rewards?", discordID),
-				Image:       "https://cdn.discordapp.com/attachments/1003381172178530494/1019165378447937556/unknown.png",
-			},
-			{
-				Title:       "Promoted!",
-				Description: fmt.Sprintf("Mochi got a vote and <@%s> can now use the `$wl` command to its fullest, win-win", discordID),
-				Image:       "https://cdn.discordapp.com/attachments/1003381172178530494/1019165378720583750/unknown.png",
-			},
-			{
-				Title:       "Thank you!",
-				Description: fmt.Sprintf("Thank you <@%s> for voting Mochi, Mochi truly is one of the greatest bots", discordID),
-				Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019183908681695282/obamamochi.jpg",
-			},
-			{
-				Title:       "Imagine not voting for Mochi",
-				Description: fmt.Sprintf("Fortunately <@%s> has redeemed themselves by voting on [%s](%s)", discordID, sourceName, sourceUrl),
-				Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019184889725206528/unknown.png",
-			},
-			{
-				Title:       "Trade offer alert!",
-				Description: fmt.Sprintf("Happy to announce that <@%s> has closed a great deal on [%s](%s)", discordID, sourceName, sourceUrl),
-				Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019188156584706048/trademochi.jpg",
-			},
-			{
-				Title:       "Mochi is grateful",
-				Description: fmt.Sprintf("Thank you <@%s> for the upvote, can Mochi have another one uwu?", discordID),
-				Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019189320600530974/unknown.png",
-			},
-			{
-				Title:       "You sure that is enough?",
-				Description: fmt.Sprintf("Absolutely, an upvote is all <@%s> needs to enjoy new perks", discordID),
-				Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019190354018308146/onepls.jpg",
-			},
-		}
-		randomIndex := rand.Intn(len(presets) - 1)
-		// user can upvote without being in a guild
+		embed := util.GenerateUpvoteMessage(discordID, source)
 		msgEmbed = discordgo.MessageEmbed{
-			Title:       presets[randomIndex].Title,
-			Description: presets[randomIndex].Description + voteRemindStr,
+			Title:       embed.Title,
+			Description: embed.Description + voteRemindStr,
 			Color:       mochiUpvoteMsgColor,
 			Timestamp:   time.Now().Format("2006-01-02T15:04:05Z07:00"),
 			Image: &discordgo.MessageEmbedImage{
-				URL: presets[randomIndex].Image,
+				URL: embed.Image,
 			},
 		}
 	}
@@ -369,6 +322,7 @@ func (d *Discord) SendUpvoteMessage(discordID, source string, isStranger bool) e
 	if err != nil {
 		return fmt.Errorf("[svc.Discord.SendUpvoteMessage] - ChannelMessageSendEmbed failed to channel %s: %s", d.mochiActivityChannelID, err.Error())
 	}
+
 	return nil
 }
 
@@ -389,4 +343,32 @@ func (d *Discord) generateGuildInviteLink(guild *discordgo.Guild) string {
 		}
 	}
 	return inviteUrl
+}
+
+// Reply to the lastest $vote message
+func (d *Discord) ReplyUpvoteMessage(msg *response.SetUpvoteMessageCacheResponse, source string) error {
+	embed := util.GenerateUpvoteMessage(msg.UserID, source)
+	voteRemindStr := "\n\nCheck your progress and vote for Mochi with `$vote`"
+	if msg.GuildID != d.mochiGuildID {
+		voteRemindStr += "\n[Join Mochi server](https://discord.gg/pChSvr4q) <:threat:1019815998116859965>"
+	}
+	msgEmbed := discordgo.MessageEmbed{
+		Title:       embed.Title,
+		Description: embed.Description + voteRemindStr,
+		Color:       mochiUpvoteMsgColor,
+		Timestamp:   time.Now().Format("2006-01-02T15:04:05Z07:00"),
+		Image: &discordgo.MessageEmbedImage{
+			URL: embed.Image,
+		},
+	}
+	_, err := d.session.ChannelMessageSendEmbedReply(msg.ChannelID, &msgEmbed, &discordgo.MessageReference{
+		MessageID: msg.MessageID,
+		ChannelID: msg.ChannelID,
+		GuildID:   msg.GuildID,
+	})
+	if err != nil {
+		d.log.Error(err, "[discord.ReplyUpvoteMessage] failed to reply")
+		return err
+	}
+	return nil
 }

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -105,6 +105,20 @@ func (mr *MockServiceMockRecorder) NotifyStealFloorPrice(price, floor, url, name
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyStealFloorPrice", reflect.TypeOf((*MockService)(nil).NotifyStealFloorPrice), price, floor, url, name, image)
 }
 
+// ReplyUpvoteMessage mocks base method.
+func (m *MockService) ReplyUpvoteMessage(msg *response.SetUpvoteMessageCacheResponse, source string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplyUpvoteMessage", msg, source)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReplyUpvoteMessage indicates an expected call of ReplyUpvoteMessage.
+func (mr *MockServiceMockRecorder) ReplyUpvoteMessage(msg, source interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplyUpvoteMessage", reflect.TypeOf((*MockService)(nil).ReplyUpvoteMessage), msg, source)
+}
+
 // SendGuildActivityLogs mocks base method.
 func (m *MockService) SendGuildActivityLogs(channelID, userID, title, description string) error {
 	m.ctrl.T.Helper()

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -17,4 +17,5 @@ type Service interface {
 	SendLevelUpMessage(logChannelID, role string, uActivity *response.HandleUserActivityResponse)
 	NotifyGmStreak(channelID string, userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error
 	SendUpvoteMessage(discordID, source string, isStranger bool) error
+	ReplyUpvoteMessage(msg *response.SetUpvoteMessageCacheResponse, source string) error
 }

--- a/pkg/util/discord.go
+++ b/pkg/util/discord.go
@@ -1,6 +1,10 @@
 package util
 
-import "strings"
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+)
 
 func isMissingPermissionsErr(msg string) bool {
 	return strings.Contains(msg, "missing permissions") && strings.Contains(msg, "50013")
@@ -20,4 +24,58 @@ func IsAcceptableErr(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return isMissingPermissionsErr(msg) || isMissingAccessErr(msg) || isMemberNotFoundErr(msg)
+}
+
+type upvoteMsg struct {
+	Title       string
+	Description string
+	Image       string
+}
+
+func GenerateUpvoteMessage(discordID, source string) *upvoteMsg {
+	sourceName, sourceUrl := UpvoteSourceNameAndUrl(source)
+	presets := []upvoteMsg{
+		{
+			Title:       "Mochi appreciates it!",
+			Description: fmt.Sprintf("<@%s> just voted for Mochi on [%s](%s)", discordID, sourceName, sourceUrl),
+			Image:       "https://cdn.discordapp.com/attachments/1003381172178530494/1019165378213068840/unknown.png",
+		},
+		{
+			Title:       "Wait, what?",
+			Description: fmt.Sprintf("<@%s> voted for Mochi, is that all you needed to do to receive rewards?", discordID),
+			Image:       "https://cdn.discordapp.com/attachments/1003381172178530494/1019165378447937556/unknown.png",
+		},
+		{
+			Title:       "Promoted!",
+			Description: fmt.Sprintf("Mochi got a vote and <@%s> can now use the `$wl` command to its fullest, win-win", discordID),
+			Image:       "https://cdn.discordapp.com/attachments/1003381172178530494/1019165378720583750/unknown.png",
+		},
+		{
+			Title:       "Thank you!",
+			Description: fmt.Sprintf("Thank you <@%s> for voting Mochi, Mochi truly is one of the greatest bots", discordID),
+			Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019183908681695282/obamamochi.jpg",
+		},
+		{
+			Title:       "Imagine not voting for Mochi",
+			Description: fmt.Sprintf("Fortunately <@%s> has redeemed themselves by voting on [%s](%s)", discordID, sourceName, sourceUrl),
+			Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019184889725206528/unknown.png",
+		},
+		{
+			Title:       "Trade offer alert!",
+			Description: fmt.Sprintf("Happy to announce that <@%s> has closed a great deal on [%s](%s)", discordID, sourceName, sourceUrl),
+			Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019188156584706048/trademochi.jpg",
+		},
+		{
+			Title:       "Mochi is grateful",
+			Description: fmt.Sprintf("Thank you <@%s> for the upvote, can Mochi have another one uwu?", discordID),
+			Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019189320600530974/unknown.png",
+		},
+		{
+			Title:       "You sure that is enough?",
+			Description: fmt.Sprintf("Absolutely, an upvote is all <@%s> needs to enjoy new perks", discordID),
+			Image:       "https://cdn.discordapp.com/attachments/986854719999864863/1019190354018308146/onepls.jpg",
+		},
+	}
+	ran := rand.Intn(len(presets) - 1)
+	return &presets[ran]
 }


### PR DESCRIPTION
**What does this PR do?**

- Add API to cache vote message data
- Update `discordgo` package `v0.25 -> v0.26`
- Bot replies to the `$vote` message if it's in 5min

Reply to message in Mochi server
![image](https://user-images.githubusercontent.com/84314071/190319583-8d518a0e-d89d-4e81-bbc1-e72725c6c951.png)

Reply to message outside Mochi server
![image](https://user-images.githubusercontent.com/84314071/190319652-d473f022-95e6-404b-8cc1-72c33e0eeafc.png)


