### PR TITLE
feat: telegram - discord associations

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -897,7 +897,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.ListRoleReactionResponse"
+                            "$ref": "#/definitions/response.DataListRoleReactionResponse"
                         }
                     }
                 }
@@ -1126,6 +1126,70 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.GetSalesTrackerConfigResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/configs/telegram": {
+            "get": {
+                "description": "Get telegram account linked with discord ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Telegram"
+                ],
+                "summary": "Get telegram account linked with discord ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "request",
+                        "name": "telegram_username",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.GetLinkedTelegramResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Link user's telegram with discord account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Telegram"
+                ],
+                "summary": "Link user's telegram with discord account",
+                "parameters": [
+                    {
+                        "description": "request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.LinkUserTelegramWithDiscordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/response.LinkUserTelegramWithDiscordResponse"
                         }
                     }
                 }
@@ -2442,7 +2506,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3681,7 +3745,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             }
@@ -3839,6 +3903,12 @@ const docTemplate = `{
                 },
                 "bot_arrived": {
                     "type": "boolean"
+                },
+                "features": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "icon": {
                     "type": "string"
@@ -4491,6 +4561,17 @@ const docTemplate = `{
                 }
             }
         },
+        "model.UserTelegramDiscordAssociation": {
+            "type": "object",
+            "properties": {
+                "discord_id": {
+                    "type": "string"
+                },
+                "telegram_username": {
+                    "type": "string"
+                }
+            }
+        },
         "model.UserWallet": {
             "type": "object",
             "properties": {
@@ -4811,6 +4892,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "query": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.LinkUserTelegramWithDiscordRequest": {
+            "type": "object",
+            "properties": {
+                "discord_id": {
+                    "type": "string"
+                },
+                "telegram_username": {
                     "type": "string"
                 }
             }
@@ -5309,6 +5401,14 @@ const docTemplate = `{
                 }
             }
         },
+        "response.DataListRoleReactionResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/response.ListRoleReactionResponse"
+                }
+            }
+        },
         "response.DefaultRole": {
             "type": "object",
             "properties": {
@@ -5594,6 +5694,14 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.GuildConfigLevelRole"
                     }
+                }
+            }
+        },
+        "response.GetLinkedTelegramResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/model.UserTelegramDiscordAssociation"
                 }
             }
         },
@@ -6165,6 +6273,28 @@ const docTemplate = `{
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.UserInvitesAggregation"
+                }
+            }
+        },
+        "response.LinkUserTelegramWithDiscordResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/response.LinkUserTelegramWithDiscordResponseData"
+                }
+            }
+        },
+        "response.LinkUserTelegramWithDiscordResponseData": {
+            "type": "object",
+            "properties": {
+                "discord_id": {
+                    "type": "string"
+                },
+                "discord_username": {
+                    "type": "string"
+                },
+                "telegram_username": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -889,7 +889,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.ListRoleReactionResponse"
+                            "$ref": "#/definitions/response.DataListRoleReactionResponse"
                         }
                     }
                 }
@@ -1118,6 +1118,70 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.GetSalesTrackerConfigResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/configs/telegram": {
+            "get": {
+                "description": "Get telegram account linked with discord ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Telegram"
+                ],
+                "summary": "Get telegram account linked with discord ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "request",
+                        "name": "telegram_username",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.GetLinkedTelegramResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Link user's telegram with discord account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Telegram"
+                ],
+                "summary": "Link user's telegram with discord account",
+                "parameters": [
+                    {
+                        "description": "request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.LinkUserTelegramWithDiscordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/response.LinkUserTelegramWithDiscordResponse"
                         }
                     }
                 }
@@ -2434,7 +2498,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3673,7 +3737,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             }
@@ -3831,6 +3895,12 @@
                 },
                 "bot_arrived": {
                     "type": "boolean"
+                },
+                "features": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "icon": {
                     "type": "string"
@@ -4483,6 +4553,17 @@
                 }
             }
         },
+        "model.UserTelegramDiscordAssociation": {
+            "type": "object",
+            "properties": {
+                "discord_id": {
+                    "type": "string"
+                },
+                "telegram_username": {
+                    "type": "string"
+                }
+            }
+        },
         "model.UserWallet": {
             "type": "object",
             "properties": {
@@ -4803,6 +4884,17 @@
                     "type": "string"
                 },
                 "query": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.LinkUserTelegramWithDiscordRequest": {
+            "type": "object",
+            "properties": {
+                "discord_id": {
+                    "type": "string"
+                },
+                "telegram_username": {
                     "type": "string"
                 }
             }
@@ -5301,6 +5393,14 @@
                 }
             }
         },
+        "response.DataListRoleReactionResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/response.ListRoleReactionResponse"
+                }
+            }
+        },
         "response.DefaultRole": {
             "type": "object",
             "properties": {
@@ -5586,6 +5686,14 @@
                     "items": {
                         "$ref": "#/definitions/model.GuildConfigLevelRole"
                     }
+                }
+            }
+        },
+        "response.GetLinkedTelegramResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/model.UserTelegramDiscordAssociation"
                 }
             }
         },
@@ -6157,6 +6265,28 @@
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.UserInvitesAggregation"
+                }
+            }
+        },
+        "response.LinkUserTelegramWithDiscordResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/response.LinkUserTelegramWithDiscordResponseData"
+                }
+            }
+        },
+        "response.LinkUserTelegramWithDiscordResponseData": {
+            "type": "object",
+            "properties": {
+                "discord_id": {
+                    "type": "string"
+                },
+                "discord_username": {
+                    "type": "string"
+                },
+                "telegram_username": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,6 +74,10 @@ definitions:
         type: boolean
       bot_arrived:
         type: boolean
+      features:
+        items:
+          type: string
+        type: array
       icon:
         type: string
       id:
@@ -499,6 +503,13 @@ definitions:
       rebellio_xp:
         type: integer
     type: object
+  model.UserTelegramDiscordAssociation:
+    properties:
+      discord_id:
+        type: string
+      telegram_username:
+        type: string
+    type: object
   model.UserWallet:
     properties:
       address:
@@ -706,6 +717,13 @@ definitions:
       guild_id:
         type: string
       query:
+        type: string
+    type: object
+  request.LinkUserTelegramWithDiscordRequest:
+    properties:
+      discord_id:
+        type: string
+      telegram_username:
         type: string
     type: object
   request.LoginRequest:
@@ -1028,6 +1046,11 @@ definitions:
       data:
         $ref: '#/definitions/response.GetUserCurrentUpvoteStreakResponse'
     type: object
+  response.DataListRoleReactionResponse:
+    properties:
+      data:
+        $ref: '#/definitions/response.ListRoleReactionResponse'
+    type: object
   response.DefaultRole:
     properties:
       guild_id:
@@ -1211,6 +1234,11 @@ definitions:
         items:
           $ref: '#/definitions/model.GuildConfigLevelRole'
         type: array
+    type: object
+  response.GetLinkedTelegramResponse:
+    properties:
+      data:
+        $ref: '#/definitions/model.UserTelegramDiscordAssociation'
     type: object
   response.GetListAllChainsResponse:
     properties:
@@ -1581,6 +1609,20 @@ definitions:
     properties:
       data:
         $ref: '#/definitions/response.UserInvitesAggregation'
+    type: object
+  response.LinkUserTelegramWithDiscordResponse:
+    properties:
+      data:
+        $ref: '#/definitions/response.LinkUserTelegramWithDiscordResponseData'
+    type: object
+  response.LinkUserTelegramWithDiscordResponseData:
+    properties:
+      discord_id:
+        type: string
+      discord_username:
+        type: string
+      telegram_username:
+        type: string
     type: object
   response.ListAllCustomTokenResponse:
     properties:
@@ -2596,7 +2638,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.ListRoleReactionResponse'
+            $ref: '#/definitions/response.DataListRoleReactionResponse'
       summary: Get all role reaction configs
       tags:
       - Config
@@ -2728,6 +2770,48 @@ paths:
       summary: Get sales tracker config
       tags:
       - Config
+  /configs/telegram:
+    get:
+      consumes:
+      - application/json
+      description: Get telegram account linked with discord ID
+      parameters:
+      - description: request
+        in: query
+        name: telegram_username
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.GetLinkedTelegramResponse'
+      summary: Get telegram account linked with discord ID
+      tags:
+      - Telegram
+    post:
+      consumes:
+      - application/json
+      description: Link user's telegram with discord account
+      parameters:
+      - description: request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/request.LinkUserTelegramWithDiscordRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/response.LinkUserTelegramWithDiscordResponse'
+      summary: Link user's telegram with discord account
+      tags:
+      - Telegram
   /configs/tokens:
     get:
       consumes:
@@ -3493,7 +3577,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete custom commands
       tags:
       - Custom Command
@@ -4455,7 +4539,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ""
       summary: Get whitelist campaign users csv
       tags:
       - Whitelist campaign

--- a/migrations/schemas/20220916154224-add_telegram_discord_id.sql
+++ b/migrations/schemas/20220916154224-add_telegram_discord_id.sql
@@ -1,0 +1,11 @@
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS user_telegram_discord_associations (
+	telegram_username TEXT NOT NULL PRIMARY KEY,
+	discord_id TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX user_telegram_discord_associations_discord_id_uidx ON user_telegram_discord_associations(discord_id);
+
+-- +migrate Down
+DROP TABLE IF EXISTS user_telegram_discord_associations;

--- a/pkg/entities/telegram.go
+++ b/pkg/entities/telegram.go
@@ -1,0 +1,40 @@
+package entities
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/defipod/mochi/pkg/model"
+	baseerrs "github.com/defipod/mochi/pkg/model/errors"
+	"github.com/defipod/mochi/pkg/request"
+	"github.com/defipod/mochi/pkg/response"
+)
+
+func (e *Entity) GetByTelegramUsername(TelegramUsername string) (*response.GetLinkedTelegramResponse, error) {
+	data, err := e.repo.UserTelegramDiscordAssociation.GetOneByTelegramUsername(TelegramUsername)
+	if err != nil && err != gorm.ErrRecordNotFound {
+		e.log.Error(err, "[entity.GetByTelegramUsername] repo.UserTelegramDiscordAssociation.GetOneByTelegramUsername() failed")
+		return nil, err
+	}
+	if err != nil {
+		e.log.Error(err, "[entity.GetByTelegramUsername] no data found")
+		return nil, baseerrs.ErrRecordNotFound
+	}
+	return &response.GetLinkedTelegramResponse{
+		Data: data,
+	}, nil
+}
+
+func (e *Entity) LinkUserTelegramWithDiscord(req request.LinkUserTelegramWithDiscordRequest) (*response.LinkUserTelegramWithDiscordResponse, error) {
+	model := model.UserTelegramDiscordAssociation{
+		DiscordID:        req.DiscordID,
+		TelegramUsername: req.TelegramUsername,
+	}
+	err := e.repo.UserTelegramDiscordAssociation.Upsert(&model)
+	if err != nil {
+		e.log.Error(err, "[entity.LinkUserTelegramWithDiscord] repo.UserTelegramDiscordAssociation.Upsert() failed")
+		return nil, err
+	}
+	return &response.LinkUserTelegramWithDiscordResponse{
+		Data: nil,
+	}, nil
+}

--- a/pkg/handler/telegram.go
+++ b/pkg/handler/telegram.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"net/http"
+
+	baseerrs "github.com/defipod/mochi/pkg/model/errors"
+	"github.com/defipod/mochi/pkg/request"
+	_ "github.com/defipod/mochi/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// GetLinkedTelegram     godoc
+// @Summary     Get telegram account linked with discord ID
+// @Description Get telegram account linked with discord ID
+// @Tags        Telegram
+// @Accept      json
+// @Produce     json
+// @Param       telegram_username query string true "request"
+// @Success     200 {object} response.GetLinkedTelegramResponse
+// @Router      /configs/telegram [get]
+func (h *Handler) GetLinkedTelegram(c *gin.Context) {
+	telegramUsername := c.Query("telegram_username")
+	if telegramUsername == "" {
+		h.log.Info("[handler.GetLinkedTelegram] - telegram_username is required")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "telegram_username is required"})
+		return
+	}
+	res, err := h.entities.GetByTelegramUsername(telegramUsername)
+	if err != nil {
+		h.log.Error(err, "[handler.GetLinkedTelegram] entity.GetByTelegramUsername() failed")
+		code := http.StatusInternalServerError
+		if err == baseerrs.ErrRecordNotFound {
+			code = http.StatusNotFound
+		}
+		c.JSON(code, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, res)
+}
+
+// LinkUserTelegramWithDiscord     godoc
+// @Summary     Link user's telegram with discord account
+// @Description Link user's telegram with discord account
+// @Tags        Telegram
+// @Accept      json
+// @Produce     json
+// @Param       req body request.LinkUserTelegramWithDiscordRequest true "request"
+// @Success     201 {object} response.LinkUserTelegramWithDiscordResponse
+// @Router      /configs/telegram [post]
+func (h *Handler) LinkUserTelegramWithDiscord(c *gin.Context) {
+	var req request.LinkUserTelegramWithDiscordRequest
+	if err := c.Bind(&req); err != nil {
+		h.log.Error(err, "[handler.LinkUserTelegramWithDiscord] Bind() failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	res, err := h.entities.LinkUserTelegramWithDiscord(req)
+	if err != nil {
+		h.log.Error(err, "[handler.LinkUserTelegramWithDiscord] entity.LinkUserTelegramWithDiscord() failed")
+		c.JSON(baseerrs.GetStatusCode(err), gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, res)
+}

--- a/pkg/model/user_telegram_discord_association.go
+++ b/pkg/model/user_telegram_discord_association.go
@@ -1,0 +1,6 @@
+package model
+
+type UserTelegramDiscordAssociation struct {
+	TelegramUsername string `json:"telegram_username"`
+	DiscordID        string `json:"discord_id"`
+}

--- a/pkg/repo/pg/repo.go
+++ b/pkg/repo/pg/repo.go
@@ -46,6 +46,7 @@ import (
 	twitterpost "github.com/defipod/mochi/pkg/repo/twitter_post"
 	upvotestreaktier "github.com/defipod/mochi/pkg/repo/upvote_streak_tiers"
 	usernftbalance "github.com/defipod/mochi/pkg/repo/user_nft_balance"
+	usertelegramdiscordassociation "github.com/defipod/mochi/pkg/repo/user_telegram_discord_association"
 	userwallet "github.com/defipod/mochi/pkg/repo/user_wallet"
 	userwatchlistitem "github.com/defipod/mochi/pkg/repo/user_watchlist_item"
 	"github.com/defipod/mochi/pkg/repo/users"
@@ -103,5 +104,6 @@ func NewRepo(db *gorm.DB) *repo.Repo {
 		UserWatchlistItem:                    userwatchlistitem.NewPG(db),
 		GuildConfigGroupNFTRole:              guildconfiggroupnftrole.NewPG(db),
 		CoingeckoSupportedTokens:             coingeckosupportedtokens.NewPG(db),
+		UserTelegramDiscordAssociation:       usertelegramdiscordassociation.NewPG(db),
 	}
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -43,6 +43,7 @@ import (
 	twitterpost "github.com/defipod/mochi/pkg/repo/twitter_post"
 	upvotestreaktier "github.com/defipod/mochi/pkg/repo/upvote_streak_tiers"
 	usernftbalance "github.com/defipod/mochi/pkg/repo/user_nft_balance"
+	usertelegramdiscordassociation "github.com/defipod/mochi/pkg/repo/user_telegram_discord_association"
 	userwallet "github.com/defipod/mochi/pkg/repo/user_wallet"
 	userwatchlistitem "github.com/defipod/mochi/pkg/repo/user_watchlist_item"
 	users "github.com/defipod/mochi/pkg/repo/users"
@@ -98,4 +99,5 @@ type Repo struct {
 	UserWatchlistItem                    userwatchlistitem.Store
 	GuildConfigGroupNFTRole              guildconfiggroupnftrole.Store
 	CoingeckoSupportedTokens             coingeckosupportedtokens.Store
+	UserTelegramDiscordAssociation       usertelegramdiscordassociation.Store
 }

--- a/pkg/repo/user_telegram_discord_association/pg.go
+++ b/pkg/repo/user_telegram_discord_association/pg.go
@@ -1,0 +1,34 @@
+package usertelegramdiscordassociation
+
+import (
+	"github.com/defipod/mochi/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type pg struct {
+	db *gorm.DB
+}
+
+func NewPG(db *gorm.DB) Store {
+	return &pg{db: db}
+}
+
+func (pg *pg) GetOneByTelegramUsername(telegramUsername string) (*model.UserTelegramDiscordAssociation, error) {
+	model := &model.UserTelegramDiscordAssociation{}
+	return model, pg.db.Where("telegram_username = ?", telegramUsername).First(model).Error
+}
+
+func (pg *pg) Upsert(model *model.UserTelegramDiscordAssociation) error {
+	tx := pg.db.Begin()
+	err := tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "telegram_username"}},
+		DoUpdates: clause.AssignmentColumns([]string{"discord_id"}),
+	}).Create(model).Error
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit().Error
+}

--- a/pkg/repo/user_telegram_discord_association/store.go
+++ b/pkg/repo/user_telegram_discord_association/store.go
@@ -1,0 +1,8 @@
+package usertelegramdiscordassociation
+
+import "github.com/defipod/mochi/pkg/model"
+
+type Store interface {
+	GetOneByTelegramUsername(telegramID string) (*model.UserTelegramDiscordAssociation, error)
+	Upsert(*model.UserTelegramDiscordAssociation) error
+}

--- a/pkg/request/telegram.go
+++ b/pkg/request/telegram.go
@@ -1,0 +1,6 @@
+package request
+
+type LinkUserTelegramWithDiscordRequest struct {
+	TelegramUsername string `json:"telegram_username"`
+	DiscordID        string `json:"discord_id"`
+}

--- a/pkg/response/telegram.go
+++ b/pkg/response/telegram.go
@@ -1,0 +1,16 @@
+package response
+
+import "github.com/defipod/mochi/pkg/model"
+
+type GetLinkedTelegramResponse struct {
+	Data *model.UserTelegramDiscordAssociation `json:"data"`
+}
+
+type LinkUserTelegramWithDiscordResponseData struct {
+	model.UserTelegramDiscordAssociation
+	DiscordUsername string `json:"discord_username"`
+}
+
+type LinkUserTelegramWithDiscordResponse struct {
+	Data *LinkUserTelegramWithDiscordResponseData `json:"data"`
+}

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -155,6 +155,12 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 			defaultTickerGroup.GET("", h.GetGuildDefaultTicker)
 			defaultTickerGroup.POST("", h.SetGuildDefaultTicker)
 		}
+
+		telegramGroup := configGroup.Group("/telegram")
+		{
+			telegramGroup.GET("", h.GetLinkedTelegram)
+			telegramGroup.POST("", h.LinkUserTelegramWithDiscord)
+		}
 	}
 
 	defiGroup := v1.Group("/defi")


### PR DESCRIPTION
**What does this PR do?**
New APIs for linking discord & telegram account
- [x] `[POST] api/v1/configs/telegram`: create linking between telegram and discord account
- [x] `[GET api/v1/configs/telegram`: get association info between telegram and discord account
