### PR TITLE
refactor: link telegram by username

### DIFF
--- a/migrations/schemas/20220919171236-alter_user_telegram_discord_associations.sql
+++ b/migrations/schemas/20220919171236-alter_user_telegram_discord_associations.sql
@@ -1,0 +1,20 @@
+
+-- +migrate Up
+DROP TABLE IF EXISTS user_telegram_discord_associations;
+
+CREATE TABLE IF NOT EXISTS user_telegram_discord_associations (
+	telegram_username TEXT NOT NULL PRIMARY KEY,
+	discord_id TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX user_telegram_discord_associations_discord_id_uidx ON user_telegram_discord_associations(discord_id);
+
+-- +migrate Down
+DROP TABLE IF EXISTS user_telegram_discord_associations;
+
+CREATE TABLE IF NOT EXISTS user_telegram_discord_associations (
+	telegram_id INTEGER NOT NULL PRIMARY KEY,
+	discord_id TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX user_telegram_discord_associations_discord_id_uidx ON user_telegram_discord_associations(discord_id);

--- a/pkg/handler/telegram.go
+++ b/pkg/handler/telegram.go
@@ -9,26 +9,30 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// GetLinkedTelegramID     godoc
+// GetLinkedTelegram     godoc
 // @Summary     Get telegram account linked with discord ID
 // @Description Get telegram account linked with discord ID
 // @Tags        Telegram
 // @Accept      json
 // @Produce     json
-// @Param       telegram_id query string true "request"
+// @Param       telegram_username query string true "request"
 // @Success     200 {object} response.GetLinkedTelegramResponse
 // @Router      /configs/telegram [get]
 func (h *Handler) GetLinkedTelegram(c *gin.Context) {
-	telegramID := c.Query("telegram_id")
-	if telegramID == "" {
-		h.log.Info("[handler.GetLinkedTelegram] - telegram_id is required")
-		c.JSON(http.StatusBadRequest, gin.H{"error": "telegram_id is required"})
+	telegramUsername := c.Query("telegram_username")
+	if telegramUsername == "" {
+		h.log.Info("[handler.GetLinkedTelegram] - telegram_username is required")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "telegram_username is required"})
 		return
 	}
-	res, err := h.entities.GetTelegramByDiscordID(telegramID)
+	res, err := h.entities.GetByTelegramUsername(telegramUsername)
 	if err != nil {
-		h.log.Error(err, "[handler.GetLinkedTelegram] entity.GetTelegramByDiscordID() failed")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		h.log.Error(err, "[handler.GetLinkedTelegram] entity.GetByTelegramUsername() failed")
+		code := http.StatusInternalServerError
+		if err == baseerrs.ErrRecordNotFound {
+			code = http.StatusNotFound
+		}
+		c.JSON(code, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, res)

--- a/pkg/model/user_telegram_discord_association.go
+++ b/pkg/model/user_telegram_discord_association.go
@@ -1,6 +1,6 @@
 package model
 
 type UserTelegramDiscordAssociation struct {
-	TelegramID int64  `json:"telegram_id"`
-	DiscordID  string `json:"discord_id"`
+	TelegramUsername string `json:"telegram_username"`
+	DiscordID        string `json:"discord_id"`
 }

--- a/pkg/repo/user_telegram_discord_association/pg.go
+++ b/pkg/repo/user_telegram_discord_association/pg.go
@@ -14,15 +14,15 @@ func NewPG(db *gorm.DB) Store {
 	return &pg{db: db}
 }
 
-func (pg *pg) GetOneByTelegramID(telegramID string) (*model.UserTelegramDiscordAssociation, error) {
+func (pg *pg) GetOneByTelegramUsername(telegramUsername string) (*model.UserTelegramDiscordAssociation, error) {
 	model := &model.UserTelegramDiscordAssociation{}
-	return model, pg.db.Where("telegram_id = ?", telegramID).First(model).Error
+	return model, pg.db.Where("telegram_username = ?", telegramUsername).First(model).Error
 }
 
 func (pg *pg) Upsert(model *model.UserTelegramDiscordAssociation) error {
 	tx := pg.db.Begin()
 	err := tx.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "telegram_id"}},
+		Columns:   []clause.Column{{Name: "telegram_username"}},
 		DoUpdates: clause.AssignmentColumns([]string{"discord_id"}),
 	}).Create(model).Error
 	if err != nil {

--- a/pkg/repo/user_telegram_discord_association/store.go
+++ b/pkg/repo/user_telegram_discord_association/store.go
@@ -3,6 +3,6 @@ package usertelegramdiscordassociation
 import "github.com/defipod/mochi/pkg/model"
 
 type Store interface {
-	GetOneByTelegramID(telegramID string) (*model.UserTelegramDiscordAssociation, error)
+	GetOneByTelegramUsername(telegramID string) (*model.UserTelegramDiscordAssociation, error)
 	Upsert(*model.UserTelegramDiscordAssociation) error
 }

--- a/pkg/request/telegram.go
+++ b/pkg/request/telegram.go
@@ -1,6 +1,6 @@
 package request
 
 type LinkUserTelegramWithDiscordRequest struct {
-	TelegramID int64  `json:"telegram_id"`
-	DiscordID  string `json:"discord_id"`
+	TelegramUsername string `json:"telegram_username"`
+	DiscordID        string `json:"discord_id"`
 }


### PR DESCRIPTION
**What does this PR do?**
Update telegram APIs
- [x] `[POST] api/v1/configs/telegram` - linking between telegram and discord account is now `discord_id` and `telegram_username` (instead of `telegram_id`)
- [x] `[GET] api/v1/configs/telegram` - get association info between telegram and discord account by `telegram_username` (instead of `telegram_id`)