### PR TITLE
fix: upsert linked telegram

### DIFF
--- a/pkg/repo/user_telegram_discord_association/pg.go
+++ b/pkg/repo/user_telegram_discord_association/pg.go
@@ -22,8 +22,8 @@ func (pg *pg) GetOneByTelegramUsername(telegramUsername string) (*model.UserTele
 func (pg *pg) Upsert(model *model.UserTelegramDiscordAssociation) error {
 	tx := pg.db.Begin()
 	err := tx.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "telegram_username"}},
-		DoUpdates: clause.AssignmentColumns([]string{"discord_id"}),
+		Columns:   []clause.Column{{Name: "discord_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"telegram_username"}),
 	}).Create(model).Error
 	if err != nil {
 		tx.Rollback()


### PR DESCRIPTION
**What does this PR do?**
-   [x] Fixed upsert query (wrong `onConflict` clause): allow to re-link/update `telegram_username` by `discord_id`

**Media**
<img width="603" alt="image" src="https://user-images.githubusercontent.com/34529672/191243018-98d5c199-976d-49de-b384-74a4f7091e34.png">
