### PR TITLE
feat: assign role verify wallet

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4513,6 +4513,9 @@ const docTemplate = `{
                 },
                 "verify_channel_id": {
                     "type": "string"
+                },
+                "verify_role_id": {
+                    "type": "string"
                 }
             }
         },
@@ -5167,6 +5170,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "verify_channel_id": {
+                    "type": "string"
+                },
+                "verify_role_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4505,6 +4505,9 @@
                 },
                 "verify_channel_id": {
                     "type": "string"
+                },
+                "verify_role_id": {
+                    "type": "string"
                 }
             }
         },
@@ -5159,6 +5162,9 @@
                     "type": "string"
                 },
                 "verify_channel_id": {
+                    "type": "string"
+                },
+                "verify_role_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -351,6 +351,8 @@ definitions:
         type: string
       verify_channel_id:
         type: string
+      verify_role_id:
+        type: string
     type: object
   model.GuildConfigWelcomeChannel:
     properties:
@@ -775,6 +777,8 @@ definitions:
       guild_id:
         type: string
       verify_channel_id:
+        type: string
+      verify_role_id:
         type: string
     type: object
   request.RoleReactionRequest:

--- a/migrations/schemas/20220922124147-alter_users_add_nr_of_join.sql.sql
+++ b/migrations/schemas/20220922124147-alter_users_add_nr_of_join.sql.sql
@@ -1,0 +1,6 @@
+
+-- +migrate Up
+ALTER TABLE guild_config_wallet_verification_messages ADD COLUMN verify_role_id TEXT;
+
+-- +migrate Down
+ALTER TABLE guild_config_wallet_verification_messages DROP COLUMN verify_role_id;

--- a/pkg/model/guild_config_wallet_verification_message.go
+++ b/pkg/model/guild_config_wallet_verification_message.go
@@ -5,6 +5,7 @@ import "time"
 type GuildConfigWalletVerificationMessage struct {
 	GuildID          string    `json:"guild_id"`
 	VerifyChannelID  string    `json:"verify_channel_id"`
+	VerifyRoleID     string    `json:"verify_role_id"`
 	Content          string    `json:"content"`
 	EmbeddedMessage  JSON      `json:"embedded_message"`
 	CreatedAt        time.Time `json:"created_at"`


### PR DESCRIPTION
Update api create verify message: `POST /api/v1/verify/config`
- [x] Allow `verify_role_id` in request or not -> it means can `$verify set #general` and `$verify set #general @verified-wallet`
<img width="1206" alt="image" src="https://user-images.githubusercontent.com/39881166/191681069-0190d7a1-04fa-4289-b40a-57728beb3f0d.png">
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/39881166/191681197-9d190744-f8b6-449d-989f-8ca164b1b51e.png">

Update logic api verify wallet: `POST /api/v1/verify`
- [x] Check if guild has config role for verify -> yes: update role for user, not: skip this step
https://www.loom.com/share/3488bfc1675946318ea4668da054d5c2