### PR TITLE
refactor: pair for watchlist

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2199,8 +2199,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created",
+                    "200": {
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.AddToWatchlistResponse"
                         }
@@ -5600,7 +5600,13 @@ const docTemplate = `{
         "response.AddToWatchlistResponseData": {
             "type": "object",
             "properties": {
-                "suggestions": {
+                "base_suggestions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.CoingeckoSupportedTokens"
+                    }
+                },
+                "target_suggestions": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.CoingeckoSupportedTokens"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2191,8 +2191,8 @@
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created",
+                    "200": {
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.AddToWatchlistResponse"
                         }
@@ -5592,7 +5592,13 @@
         "response.AddToWatchlistResponseData": {
             "type": "object",
             "properties": {
-                "suggestions": {
+                "base_suggestions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.CoingeckoSupportedTokens"
+                    }
+                },
+                "target_suggestions": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.CoingeckoSupportedTokens"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -971,7 +971,11 @@ definitions:
     type: object
   response.AddToWatchlistResponseData:
     properties:
-      suggestions:
+      base_suggestions:
+        items:
+          $ref: '#/definitions/model.CoingeckoSupportedTokens'
+        type: array
+      target_suggestions:
         items:
           $ref: '#/definitions/model.CoingeckoSupportedTokens'
         type: array
@@ -3658,8 +3662,8 @@ paths:
       produces:
       - application/json
       responses:
-        "201":
-          description: Created
+        "200":
+          description: OK
           schema:
             $ref: '#/definitions/response.AddToWatchlistResponse'
       summary: Add to user's watchlist

--- a/pkg/handler/defi.go
+++ b/pkg/handler/defi.go
@@ -320,7 +320,7 @@ func (h *Handler) GetUserWatchlist(c *gin.Context) {
 // @Accept      json
 // @Produce     json
 // @Param       req body request.AddToWatchlistRequest true "request"
-// @Success     201 {object} response.AddToWatchlistResponse
+// @Success     200 {object} response.AddToWatchlistResponse
 // @Router      /defi/watchlist [post]
 func (h *Handler) AddToWatchlist(c *gin.Context) {
 	var req request.AddToWatchlistRequest
@@ -335,7 +335,7 @@ func (h *Handler) AddToWatchlist(c *gin.Context) {
 		c.JSON(baseerrs.GetStatusCode(err), gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusCreated, res)
+	c.JSON(http.StatusOK, res)
 }
 
 // RemoveFromWatchlist     godoc

--- a/pkg/response/defi.go
+++ b/pkg/response/defi.go
@@ -131,7 +131,7 @@ type GetCoinResponseWrapper struct {
 type CompareTokenReponseData struct {
 	BaseCoin              *GetCoinResponse                 `json:"base_coin"`
 	TargetCoin            *GetCoinResponse                 `json:"target_coin"`
-	Ratios                []float32                        `json:"ratios"`
+	Ratios                []float64                        `json:"ratios"`
 	Times                 []string                         `json:"times"`
 	BaseCoinSuggestions   []model.CoingeckoSupportedTokens `json:"base_coin_suggestions"`
 	TargetCoinSuggestions []model.CoingeckoSupportedTokens `json:"target_coin_suggestions"`
@@ -144,7 +144,8 @@ type CompareTokenResponse struct {
 }
 
 type AddToWatchlistResponseData struct {
-	Suggestions []model.CoingeckoSupportedTokens `json:"suggestions"`
+	BaseSuggestions   []model.CoingeckoSupportedTokens `json:"base_suggestions"`
+	TargetSuggestions []model.CoingeckoSupportedTokens `json:"target_suggestions"`
 }
 
 type AddToWatchlistResponse struct {

--- a/pkg/service/coingecko/coingecko.go
+++ b/pkg/service/coingecko/coingecko.go
@@ -80,8 +80,8 @@ func (c *CoinGecko) GetCoinPrice(coinIDs []string, currency string) (map[string]
 	return prices, nil
 }
 
-func (c *CoinGecko) GetHistoryCoinInfo(sourceSymbol string, interval string) (resp [][]float32, err error, statusCode int) {
-	statusCode, err = util.FetchData(fmt.Sprintf(c.getCoinOhlc, sourceSymbol, interval), &resp)
+func (c *CoinGecko) GetHistoryCoinInfo(sourceSymbol string, days string) (resp [][]float64, err error, statusCode int) {
+	statusCode, err = util.FetchData(fmt.Sprintf(c.getCoinOhlc, sourceSymbol, days), &resp)
 	if err != nil || statusCode != http.StatusOK {
 		return nil, err, statusCode
 	}

--- a/pkg/service/coingecko/mocks/service.go
+++ b/pkg/service/coingecko/mocks/service.go
@@ -99,10 +99,10 @@ func (mr *MockServiceMockRecorder) GetHistoricalMarketData(req interface{}) *gom
 }
 
 // GetHistoryCoinInfo mocks base method.
-func (m *MockService) GetHistoryCoinInfo(sourceSymbol, interval string) ([][]float32, error, int) {
+func (m *MockService) GetHistoryCoinInfo(sourceSymbol, interval string) ([][]float64, error, int) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHistoryCoinInfo", sourceSymbol, interval)
-	ret0, _ := ret[0].([][]float32)
+	ret0, _ := ret[0].([][]float64)
 	ret1, _ := ret[1].(error)
 	ret2, _ := ret[2].(int)
 	return ret0, ret1, ret2

--- a/pkg/service/coingecko/service.go
+++ b/pkg/service/coingecko/service.go
@@ -9,7 +9,7 @@ type Service interface {
 	GetHistoricalMarketData(req *request.GetMarketChartRequest) (res *response.CoinPriceHistoryResponse, err error, statusCode int)
 	GetCoin(coinID string) (res *response.GetCoinResponse, err error, statusCode int)
 	GetCoinPrice(coinIDs []string, currency string) (map[string]float64, error)
-	GetHistoryCoinInfo(sourceSymbol string, interval string) (res [][]float32, err error, statusCode int)
+	GetHistoryCoinInfo(sourceSymbol string, interval string) (res [][]float64, err error, statusCode int)
 	GetCoinsMarketData(ids []string) (res []response.CoinMarketItemData, err error, statusCode int)
 	GetSupportedCoins() (res []response.CoingeckoSupportedTokenResponse, err error, statusCode int)
 }


### PR DESCRIPTION
**What does this PR do?**
Refactor watchlist APIs:
- [x] `[POST] /api/v1/defi/watchlist`: no more requesting to Binance API
- [x] `[GET] /api/v1/defi/watchlist`: reuse behavior from `CompareToken` instead of requesting to BinanceAPI, also refactor response