### PR TITLE
feat: handle bot removed event

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4445,6 +4445,9 @@ const docTemplate = `{
         "model.DiscordGuild": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "alias": {
                     "type": "string"
                 },
@@ -5600,8 +5603,11 @@ const docTemplate = `{
         "request.UpdateGuildRequest": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "global_xp": {
-                    "type": "string"
+                    "type": "boolean"
                 },
                 "log_channel": {
                     "type": "string"
@@ -5966,6 +5972,17 @@ const docTemplate = `{
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.RoleReactionResponse"
+                },
+                "page": {
+                    "description": "page index",
+                    "type": "integer"
+                },
+                "size": {
+                    "description": "page size",
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },
@@ -5974,6 +5991,17 @@ const docTemplate = `{
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.ListRoleReactionResponse"
+                },
+                "page": {
+                    "description": "page index",
+                    "type": "integer"
+                },
+                "size": {
+                    "description": "page size",
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },
@@ -6162,6 +6190,9 @@ const docTemplate = `{
         "response.GetGuildResponse": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "alias": {
                     "type": "string"
                 },
@@ -6276,6 +6307,17 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.GuildConfigLevelRole"
                     }
+                },
+                "page": {
+                    "description": "page index",
+                    "type": "integer"
+                },
+                "size": {
+                    "description": "page size",
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4437,6 +4437,9 @@
         "model.DiscordGuild": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "alias": {
                     "type": "string"
                 },
@@ -5592,8 +5595,11 @@
         "request.UpdateGuildRequest": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "global_xp": {
-                    "type": "string"
+                    "type": "boolean"
                 },
                 "log_channel": {
                     "type": "string"
@@ -5958,6 +5964,17 @@
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.RoleReactionResponse"
+                },
+                "page": {
+                    "description": "page index",
+                    "type": "integer"
+                },
+                "size": {
+                    "description": "page size",
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },
@@ -5966,6 +5983,17 @@
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.ListRoleReactionResponse"
+                },
+                "page": {
+                    "description": "page index",
+                    "type": "integer"
+                },
+                "size": {
+                    "description": "page size",
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },
@@ -6154,6 +6182,9 @@
         "response.GetGuildResponse": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "alias": {
                     "type": "string"
                 },
@@ -6268,6 +6299,17 @@
                     "items": {
                         "$ref": "#/definitions/model.GuildConfigLevelRole"
                     }
+                },
+                "page": {
+                    "description": "page index",
+                    "type": "integer"
+                },
+                "size": {
+                    "description": "page size",
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -146,6 +146,8 @@ definitions:
     type: object
   model.DiscordGuild:
     properties:
+      active:
+        type: boolean
       alias:
         type: string
       bot_scopes:
@@ -897,8 +899,10 @@ definitions:
     type: object
   request.UpdateGuildRequest:
     properties:
+      active:
+        type: boolean
       global_xp:
-        type: string
+        type: boolean
       log_channel:
         type: string
     type: object
@@ -1134,11 +1138,27 @@ definitions:
     properties:
       data:
         $ref: '#/definitions/response.RoleReactionResponse'
+      page:
+        description: page index
+        type: integer
+      size:
+        description: page size
+        type: integer
+      total:
+        type: integer
     type: object
   response.DataListRoleReactionResponse:
     properties:
       data:
         $ref: '#/definitions/response.ListRoleReactionResponse'
+      page:
+        description: page index
+        type: integer
+      size:
+        description: page size
+        type: integer
+      total:
+        type: integer
     type: object
   response.DefaultRole:
     properties:
@@ -1258,6 +1278,8 @@ definitions:
     type: object
   response.GetGuildResponse:
     properties:
+      active:
+        type: boolean
       alias:
         type: string
       bot_scopes:
@@ -1332,6 +1354,14 @@ definitions:
         items:
           $ref: '#/definitions/model.GuildConfigLevelRole'
         type: array
+      page:
+        description: page index
+        type: integer
+      size:
+        description: page size
+        type: integer
+      total:
+        type: integer
     type: object
   response.GetLinkedTelegramResponse:
     properties:

--- a/migrations/schemas/20220928145213-add_guild_active_status.sql
+++ b/migrations/schemas/20220928145213-add_guild_active_status.sql
@@ -1,0 +1,6 @@
+
+-- +migrate Up
+ALTER TABLE discord_guilds ADD COLUMN IF NOT EXISTS active BOOLEAN DEFAULT TRUE;
+
+-- +migrate Down
+ALTER TABLE discord_guilds DROP COLUMN IF EXISTS active;

--- a/pkg/entities/guild_test.go
+++ b/pkg/entities/guild_test.go
@@ -86,6 +86,7 @@ func TestEntity_GetGuild(t *testing.T) {
 				Name:      "a",
 				BotScopes: model.JSONArrayString{"*"},
 				GlobalXP:  false,
+				Active:    true,
 			},
 			wantErr: false,
 		},

--- a/pkg/handler/guilds.go
+++ b/pkg/handler/guilds.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/defipod/mochi/pkg/entities"
 	"github.com/defipod/mochi/pkg/logger"
@@ -184,13 +183,8 @@ func (h *Handler) UpdateGuild(c *gin.Context) {
 		return
 	}
 
-	omit := "log_channel"
-	if req.GlobalXP == "" {
-		omit = "global_xp"
-	}
-	globalXP := strings.EqualFold(req.GlobalXP, "true")
-	if err := h.entities.UpdateGuild(omit, guildID, globalXP, req.LogChannel); err != nil {
-		h.log.Fields(logger.Fields{"guildID": guildID, "globalXP": req.GlobalXP, "logChannel": req.LogChannel}).Error(err, "[handler.UpdateGuild] - failed to update guild")
+	if err := h.entities.UpdateGuild(guildID, req); err != nil {
+		h.log.Fields(logger.Fields{"guildID": guildID, "req": req}).Error(err, "[handler.UpdateGuild] - failed to update guild")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
 		return
 	}

--- a/pkg/handler/webhook_test.go
+++ b/pkg/handler/webhook_test.go
@@ -62,7 +62,7 @@ func Test_HandleDiscordWebhook(t *testing.T) {
 	}
 
 	// upsert guild
-	if err := repo.DiscordGuilds.CreateIfNotExists(model.DiscordGuild{
+	if err := repo.DiscordGuilds.CreateOrReactivate(model.DiscordGuild{
 		ID:        "878692765683298344",
 		Name:      "test-server",
 		BotScopes: model.JSONArrayString{"*"},

--- a/pkg/model/discord_guild.go
+++ b/pkg/model/discord_guild.go
@@ -12,4 +12,5 @@ type DiscordGuild struct {
 	GuildConfigInviteTracker GuildConfigInviteTracker `json:"-" gorm:"foreignkey:GuildID"`
 	GlobalXP                 bool                     `json:"global_xp"`
 	LogChannel               string                   `json:"log_channel"`
+	Active                   bool                     `json:"active"`
 }

--- a/pkg/repo/discord_guilds/mocks/store.go
+++ b/pkg/repo/discord_guilds/mocks/store.go
@@ -34,18 +34,18 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// CreateIfNotExists mocks base method.
-func (m *MockStore) CreateIfNotExists(guild model.DiscordGuild) error {
+// CreateOrReactivate mocks base method.
+func (m *MockStore) CreateOrReactivate(guild model.DiscordGuild) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateIfNotExists", guild)
+	ret := m.ctrl.Call(m, "CreateOrReactivate", guild)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateIfNotExists indicates an expected call of CreateIfNotExists.
-func (mr *MockStoreMockRecorder) CreateIfNotExists(guild interface{}) *gomock.Call {
+// CreateOrReactivate indicates an expected call of CreateOrReactivate.
+func (mr *MockStoreMockRecorder) CreateOrReactivate(guild interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIfNotExists", reflect.TypeOf((*MockStore)(nil).CreateIfNotExists), guild)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrReactivate", reflect.TypeOf((*MockStore)(nil).CreateOrReactivate), guild)
 }
 
 // GetByID mocks base method.
@@ -79,15 +79,15 @@ func (mr *MockStoreMockRecorder) Gets() *gomock.Call {
 }
 
 // Update mocks base method.
-func (m *MockStore) Update(omit string, guild model.DiscordGuild) error {
+func (m *MockStore) Update(guild *model.DiscordGuild) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", omit, guild)
+	ret := m.ctrl.Call(m, "Update", guild)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockStoreMockRecorder) Update(omit, guild interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) Update(guild interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockStore)(nil).Update), omit, guild)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockStore)(nil).Update), guild)
 }

--- a/pkg/repo/discord_guilds/store.go
+++ b/pkg/repo/discord_guilds/store.go
@@ -5,6 +5,6 @@ import "github.com/defipod/mochi/pkg/model"
 type Store interface {
 	Gets() ([]model.DiscordGuild, error)
 	GetByID(id string) (*model.DiscordGuild, error)
-	CreateIfNotExists(guild model.DiscordGuild) error
-	Update(omit string, guild model.DiscordGuild) error
+	CreateOrReactivate(guild model.DiscordGuild) error
+	Update(guild *model.DiscordGuild) error
 }

--- a/pkg/request/guild.go
+++ b/pkg/request/guild.go
@@ -6,6 +6,13 @@ type CreateGuildRequest struct {
 }
 
 type UpdateGuildRequest struct {
-	GlobalXP   string `json:"global_xp"`
-	LogChannel string `json:"log_channel"`
+	GlobalXP   *bool   `json:"global_xp"`
+	LogChannel *string `json:"log_channel"`
+	Active     *bool   `json:"active"`
+}
+
+type HandleGuildDeleteRequest struct {
+	GuildID   string `json:"guild_id"`
+	GuildName string `json:"guild_name"`
+	IconURL   string `json:"icon_url"`
 }

--- a/pkg/request/webhook.go
+++ b/pkg/request/webhook.go
@@ -26,23 +26,35 @@ type WebhookUpvoteDiscordBot struct {
 }
 
 const (
-	GUILD_MEMBER_ADD        = "guildMemberAdd"
-	MESSAGE_CREATE          = "messageCreate"
-	MESSAGE_DELETE          = "messageDelete"
-	SALES_CREATE            = "salesCreate"
-	GUILD_CREATE            = "guildCreate"
+	// guild
+	GUILD_CREATE = "guildCreate"
+	GUILD_DELETE = "guildDelete"
+	// member
+	GUILD_MEMBER_ADD = "guildMemberAdd"
+	// message
+	MESSAGE_CREATE = "messageCreate"
+	MESSAGE_DELETE = "messageDelete"
+	// reaction
 	MESSAGE_REACTION_ADD    = "messageReactionAdd"
 	MESSAGE_REACTION_REMOVE = "messageReactionRemove"
+	// sales
+	SALES_CREATE = "salesCreate"
 )
 
 var acceptedEvents = map[string]bool{
-	GUILD_MEMBER_ADD:        true,
-	MESSAGE_CREATE:          true,
-	MESSAGE_DELETE:          true,
-	SALES_CREATE:            true,
-	GUILD_CREATE:            true,
+	// guild
+	GUILD_CREATE: true,
+	GUILD_DELETE: true,
+	// member
+	GUILD_MEMBER_ADD: true,
+	// message
+	MESSAGE_DELETE: true,
+	MESSAGE_CREATE: true,
+	// reaction
 	MESSAGE_REACTION_ADD:    true,
 	MESSAGE_REACTION_REMOVE: true,
+	// sales
+	SALES_CREATE: true,
 }
 
 func (input *HandleDiscordWebhookRequest) Bind(c *gin.Context) error {

--- a/pkg/response/guild.go
+++ b/pkg/response/guild.go
@@ -14,6 +14,7 @@ type GetGuildResponse struct {
 	LogChannel   string   `json:"log_channel"`
 	LogChannelID string   `json:"log_channel_id"`
 	GlobalXP     bool     `json:"global_xp"`
+	Active       bool     `json:"active"`
 }
 
 type ListAllCustomTokenResponse struct {

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -388,3 +388,18 @@ func (d *Discord) ReplyUpvoteMessage(msg *response.SetUpvoteMessageCacheResponse
 	}
 	return nil
 }
+
+func (d *Discord) NotifyGuildDelete(guildID, guildName, iconURL string, guildsLeft int) error {
+	msg := &discordgo.MessageEmbed{
+		Title:       "Time to say goodbye!",
+		Thumbnail:   &discordgo.MessageEmbedThumbnail{URL: iconURL},
+		Description: fmt.Sprintf("Mochi just left guild `%s`\nGuilds left: `%v`", guildName, guildsLeft),
+		Color:       mochiLogColor,
+		Timestamp:   time.Now().Format("2006-01-02T15:04:05Z07:00"),
+	}
+	_, err := d.session.ChannelMessageSendEmbed(d.mochiLogChannelID, msg)
+	if err != nil {
+		d.log.Fields(logger.Fields{"msg": msg}).Error(err, "session.ChannelMessageSendEmbed() failed")
+	}
+	return err
+}

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -63,6 +63,20 @@ func (mr *MockServiceMockRecorder) NotifyGmStreak(channelID, userDiscordID, stre
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyGmStreak", reflect.TypeOf((*MockService)(nil).NotifyGmStreak), channelID, userDiscordID, streakCount, podTownXps)
 }
 
+// NotifyGuildDelete mocks base method.
+func (m *MockService) NotifyGuildDelete(guildID, guildName, iconURL string, guildsLeft int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NotifyGuildDelete", guildID, guildName, iconURL, guildsLeft)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NotifyGuildDelete indicates an expected call of NotifyGuildDelete.
+func (mr *MockServiceMockRecorder) NotifyGuildDelete(guildID, guildName, iconURL, guildsLeft interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyGuildDelete", reflect.TypeOf((*MockService)(nil).NotifyGuildDelete), guildID, guildName, iconURL, guildsLeft)
+}
+
 // NotifyNewGuild mocks base method.
 func (m *MockService) NotifyNewGuild(newGuildID string, count int) error {
 	m.ctrl.T.Helper()

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -18,4 +18,5 @@ type Service interface {
 	NotifyGmStreak(channelID string, userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error
 	SendUpvoteMessage(discordID, source string, isStranger bool) error
 	ReplyUpvoteMessage(msg *response.SetUpvoteMessageCacheResponse, source string) error
+	NotifyGuildDelete(guildID, guildName, iconURL string, guildsLeft int) error
 }


### PR DESCRIPTION
**What does this PR do?**
1. Handle `guildDelete` event sent to `/webhook`:
- [x] Add `active` column for `discord_guilds`
- [x] Update guild's activation status to `false`
- [x] Send notification to Mochi's channel log
2. SELECT DB queries from `discord_guilds` will exclude guilds with `active` = `false`

**Media (Loom or gif)**
<img width="397" alt="image" src="https://user-images.githubusercontent.com/34529672/192758425-0e21ebe6-60e7-42f9-bff1-29ed6eac7605.png">