### PR TITLE
fix: inactive when joins new guild

### DIFF
--- a/pkg/entities/guild.go
+++ b/pkg/entities/guild.go
@@ -21,6 +21,7 @@ func (e *Entity) CreateGuild(guild request.CreateGuildRequest) error {
 		BotScopes: model.JSONArrayString{
 			"*",
 		},
+		Active: true,
 	})
 	if err != nil {
 		e.log.Fields(logger.Fields{"guildID": guild.ID}).Errorf(err, "[e.CreateGuild] repo.DiscordGuilds.CreateOrReactivate() failed")


### PR DESCRIPTION
**What does this PR do?**
-   [x] When mochi joins new guild, `active` always = false
