### PR TITLE
fix: nft watchlist default data

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2731,7 +2731,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": ""
+                        "description": "No Content"
                     }
                 }
             }
@@ -4175,7 +4175,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "OK"
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2723,7 +2723,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": ""
+                        "description": "No Content"
                     }
                 }
             }
@@ -4167,7 +4167,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "OK"
                     }
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3984,7 +3984,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: ""
+          description: No Content
       summary: Delete custom commands
       tags:
       - Custom Command
@@ -5083,7 +5083,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: ""
+          description: OK
       summary: Get whitelist campaign users csv
       tags:
       - Whitelist campaign

--- a/pkg/entities/nfts.go
+++ b/pkg/entities/nfts.go
@@ -1040,6 +1040,10 @@ func (e *Entity) GetNftWatchlist(req *request.GetNftWatchlistRequest) (*response
 		return nil, err
 	}
 
+	if len(list) == 0 {
+		list = e.getDefaultNFTWatchlistItems()
+	}
+
 	res := make([]response.GetNftWatchlist, 0)
 	for _, itm := range list {
 		data, err := e.indexer.GetNFTCollectionTickersForWl(itm.CollectionAddress)
@@ -1099,4 +1103,11 @@ func (e *Entity) GetNftWatchlist(req *request.GetNftWatchlistRequest) (*response
 		res = append(res, itmRes)
 	}
 	return &response.GetNftWatchlistResponse{Data: res}, nil
+}
+
+func (e *Entity) getDefaultNFTWatchlistItems() []model.UserNftWatchlistItem {
+	return []model.UserNftWatchlistItem{
+		{CollectionAddress: "0x7acee5d0acc520fab33b3ea25d4feef1ffebde73", Symbol: "NEKO", ChainId: 250},
+		{CollectionAddress: "0x2ab5c606a5aa2352f8072b9e2e8a213033e2c4c9", Symbol: "MGC", ChainId: 250},
+	}
 }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add NEKO and MAGICATS as default collection if user haven't added one

**How to test**

```
curl -X 'GET' \
  'http://localhost:8200/api/v1/nfts/watchlist?user_id=205167514731151360&page=0&size=12' \
  -H 'accept: application/json'
```
