### PR TITLE
chore: fix welcome config

### DIFF
--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -53,7 +53,12 @@ func (e *Entity) GetWelcomeChannelConfig(guildID string) (*model.GuildConfigWelc
 
 func (e *Entity) UpsertWelcomeChannelConfig(req request.UpsertWelcomeConfigRequest) (*model.GuildConfigWelcomeChannel, error) {
 	if req.WelcomeMsg == "" {
-		req.WelcomeMsg = "Greetings $name :wave: Welcome to the guild! Hope you enjoy your stay."
+		previousConfig, err := e.repo.GuildConfigWelcomeChannel.GetByGuildID(req.GuildID)
+		if err == gorm.ErrRecordNotFound {
+			req.WelcomeMsg = "Greetings $name :wave: Welcome to the guild! Hope you enjoy your stay."
+		} else {
+			req.WelcomeMsg = previousConfig.WelcomeMessage
+		}
 	}
 	config, err := e.repo.GuildConfigWelcomeChannel.UpsertOne(&model.GuildConfigWelcomeChannel{
 		GuildID:        req.GuildID,


### PR DESCRIPTION
**What does this PR do?**

- Before: `$welcome set channel` will reset welcome message to default
- Now: `$welcome set channel` will keep original message
