### PR TITLE
feat: sb start stop conversation

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4942,6 +4942,9 @@ const docTemplate = `{
                 "quantity": {
                     "type": "integer"
                 },
+                "reaction_type": {
+                    "type": "string"
+                },
                 "repost_channel_id": {
                     "type": "string"
                 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1172,6 +1172,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/configs/repost-reactions/start-stop": {
+            "post": {
+                "description": "Config Respost reaction with start stop",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Config"
+                ],
+                "summary": "Config Respost reaction with start stop",
+                "parameters": [
+                    {
+                        "description": "Config repost reaction start stop request",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.ConfigRepostReactionStartStop"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseMessage"
+                        }
+                    }
+                }
+            }
+        },
         "/configs/repost-reactions/{guild_id}": {
             "get": {
                 "description": "Get Respost reaction configs",
@@ -2802,7 +2836,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": ""
+                        "description": "No Content"
                     }
                 }
             }
@@ -3711,6 +3745,11 @@ const docTemplate = `{
                 "summary": "Get user quest list",
                 "parameters": [
                     {
+                        "type": "integer",
+                        "name": "quantity",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "name": "routine",
                         "in": "query"
@@ -4447,7 +4486,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "OK"
                     }
                 }
             }
@@ -5626,6 +5665,23 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "role_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.ConfigRepostReactionStartStop": {
+            "type": "object",
+            "properties": {
+                "emoji_start": {
+                    "type": "string"
+                },
+                "emoji_stop": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "repost_channel_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1164,6 +1164,40 @@
                 }
             }
         },
+        "/configs/repost-reactions/start-stop": {
+            "post": {
+                "description": "Config Respost reaction with start stop",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Config"
+                ],
+                "summary": "Config Respost reaction with start stop",
+                "parameters": [
+                    {
+                        "description": "Config repost reaction start stop request",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.ConfigRepostReactionStartStop"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseMessage"
+                        }
+                    }
+                }
+            }
+        },
         "/configs/repost-reactions/{guild_id}": {
             "get": {
                 "description": "Get Respost reaction configs",
@@ -2794,7 +2828,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": ""
+                        "description": "No Content"
                     }
                 }
             }
@@ -3703,6 +3737,11 @@
                 "summary": "Get user quest list",
                 "parameters": [
                     {
+                        "type": "integer",
+                        "name": "quantity",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "name": "routine",
                         "in": "query"
@@ -4439,7 +4478,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "OK"
                     }
                 }
             }
@@ -5618,6 +5657,23 @@
                     "type": "integer"
                 },
                 "role_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.ConfigRepostReactionStartStop": {
+            "type": "object",
+            "properties": {
+                "emoji_start": {
+                    "type": "string"
+                },
+                "emoji_stop": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "repost_channel_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4934,6 +4934,9 @@
                 "quantity": {
                     "type": "integer"
                 },
+                "reaction_type": {
+                    "type": "string"
+                },
                 "repost_channel_id": {
                     "type": "string"
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -293,6 +293,8 @@ definitions:
         type: string
       quantity:
         type: integer
+      reaction_type:
+        type: string
       repost_channel_id:
         type: string
     type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -741,6 +741,17 @@ definitions:
       role_id:
         type: string
     type: object
+  request.ConfigRepostReactionStartStop:
+    properties:
+      emoji_start:
+        type: string
+      emoji_stop:
+        type: string
+      guild_id:
+        type: string
+      repost_channel_id:
+        type: string
+    type: object
   request.ConfigRepostRequest:
     properties:
       emoji:
@@ -3341,6 +3352,28 @@ paths:
       summary: edit message repost
       tags:
       - Config
+  /configs/repost-reactions/start-stop:
+    post:
+      consumes:
+      - application/json
+      description: Config Respost reaction with start stop
+      parameters:
+      - description: Config repost reaction start stop request
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/request.ConfigRepostReactionStartStop'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.ResponseMessage'
+      summary: Config Respost reaction with start stop
+      tags:
+      - Config
   /configs/sales-tracker:
     get:
       consumes:
@@ -4294,7 +4327,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: ""
+          description: No Content
       summary: Delete custom commands
       tags:
       - Custom Command
@@ -4994,6 +5027,9 @@ paths:
       description: Get user quest list
       parameters:
       - in: query
+        name: quantity
+        type: integer
+      - in: query
         name: routine
         type: string
       - in: query
@@ -5526,7 +5562,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: ""
+          description: OK
       summary: Get whitelist campaign users csv
       tags:
       - Whitelist campaign

--- a/migrations/schemas/20221013134724-conversation_repost_histories.sql
+++ b/migrations/schemas/20221013134724-conversation_repost_histories.sql
@@ -1,0 +1,18 @@
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS conversation_repost_histories (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    guild_id TEXT,
+    origin_channel_id TEXT,
+    origin_start_message_id TEXT,
+    origin_stop_message_id TEXT,
+    repost_channel_id TEXT,
+    created_at timestamp default now()
+);
+
+create unique index conversation_repost_histories_guild_id_origin_channel_id_origin_start_message_id_uindex
+    on conversation_repost_histories (guild_id, origin_channel_id, origin_start_message_id);
+ALTER TABLE guild_config_repost_reactions ADD COLUMN IF NOT EXISTS reaction_type text;
+-- +migrate Down
+DROP TABLE IF EXISTS conversation_repost_histories;
+ALTER TABLE guild_config_repost_reactions DROP COLUMN IF EXISTS reaction_type;

--- a/migrations/schemas/20221013134724-conversation_repost_histories.sql
+++ b/migrations/schemas/20221013134724-conversation_repost_histories.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS conversation_repost_histories (
 
 create unique index conversation_repost_histories_guild_id_origin_channel_id_origin_start_message_id_uindex
     on conversation_repost_histories (guild_id, origin_channel_id, origin_start_message_id);
-ALTER TABLE guild_config_repost_reactions ADD COLUMN IF NOT EXISTS reaction_type text;
+ALTER TABLE guild_config_repost_reactions ADD COLUMN IF NOT EXISTS reaction_type text default 'message';
 -- +migrate Down
 DROP TABLE IF EXISTS conversation_repost_histories;
 ALTER TABLE guild_config_repost_reactions DROP COLUMN IF EXISTS reaction_type;

--- a/pkg/consts/configs.go
+++ b/pkg/consts/configs.go
@@ -1,0 +1,6 @@
+package consts
+
+const (
+	ReactionTypeMessage      = "message"
+	ReactionTypeConversation = "conversation"
+)

--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/defipod/mochi/pkg/consts"
 	"github.com/defipod/mochi/pkg/logger"
 	"github.com/defipod/mochi/pkg/model"
 	"github.com/defipod/mochi/pkg/request"
@@ -465,7 +466,7 @@ func (e *Entity) ConfigRepostReaction(req request.ConfigRepostRequest) error {
 		Emoji:           req.Emoji,
 		Quantity:        req.Quantity,
 		RepostChannelID: req.RepostChannelID,
-		ReactionType:    "message",
+		ReactionType:    consts.ReactionTypeMessage,
 	})
 }
 
@@ -475,7 +476,7 @@ func (e *Entity) CreateConfigRepostReactionStartStop(req request.ConfigRepostRea
 		EmojiStart:      req.EmojiStart,
 		EmojiStop:       req.EmojiStop,
 		RepostChannelID: req.RepostChannelID,
-		ReactionType:    "conversation",
+		ReactionType:    consts.ReactionTypeConversation,
 	})
 }
 

--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -465,6 +465,17 @@ func (e *Entity) ConfigRepostReaction(req request.ConfigRepostRequest) error {
 		Emoji:           req.Emoji,
 		Quantity:        req.Quantity,
 		RepostChannelID: req.RepostChannelID,
+		ReactionType:    "message",
+	})
+}
+
+func (e *Entity) CreateConfigRepostReactionStartStop(req request.ConfigRepostReactionStartStop) error {
+	return e.repo.GuildConfigRepostReaction.UpsertOne(model.GuildConfigRepostReaction{
+		GuildID:         req.GuildID,
+		EmojiStart:      req.EmojiStart,
+		EmojiStop:       req.EmojiStop,
+		RepostChannelID: req.RepostChannelID,
+		ReactionType:    "conversation",
 	})
 }
 

--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -472,7 +472,7 @@ func (e *Entity) GetGuildRepostReactionConfigs(guildID string) ([]model.GuildCon
 	return e.repo.GuildConfigRepostReaction.GetByGuildID(guildID)
 }
 
-func (e *Entity) CreateRepostReactionEvent(req request.MessageReactionRequest) (*model.MessageRepostHistory, error) {
+func (e *Entity) CreateRepostMessageReactionEvent(req request.MessageReactionRequest) (*model.MessageRepostHistory, error) {
 	conf, err := e.repo.GuildConfigRepostReaction.GetByReaction(req.GuildID, req.Reaction)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -542,6 +542,65 @@ func (e *Entity) CreateRepostReactionEvent(req request.MessageReactionRequest) (
 	}
 
 	return &repostMsgRes, nil
+}
+
+func (e *Entity) CreateRepostConversationReactionEvent(req request.MessageReactionRequest) (*model.ConversationRepostHistories, error) {
+	configConversation, err := e.repo.GuildConfigRepostReaction.GetByReactionConversationStartOrStop(req.GuildID, req.Reaction)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		e.log.Fields(logger.Fields{"guildID": req.GuildID, "reaction": req.Reaction}).Error(err, "[e.CreateRepostReactionEvent] failed to get guild config repost reaction")
+		return nil, err
+	}
+
+	if req.Reaction == configConversation.EmojiStart {
+		// start conversation repost by create record with origin_start_message_id
+		err := e.repo.ConversationRepostHistories.Upsert(model.ConversationRepostHistories{
+			GuildID:              req.GuildID,
+			OriginChannelID:      req.ChannelID,
+			OriginStartMessageID: req.MessageID,
+			RepostChannelID:      configConversation.RepostChannelID,
+		})
+		if err != nil {
+			e.log.Fields(logger.Fields{"req": req}).Error(err, "[e.CreateRepostReactionEvent] failed to create conversation repost history")
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	if req.Reaction == configConversation.EmojiStop {
+		// stop conversation repost by update record with origin_stop_message_id
+		// first get with channel and guild id to see if theres any started conversation
+		// - yes: get and update with stop message id
+		// - no: return nil
+		conversationRepostHistory, err := e.repo.ConversationRepostHistories.GetByGuildAndChannel(req.GuildID, req.ChannelID)
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return nil, nil
+			}
+			e.log.Fields(logger.Fields{"req": req}).Error(err, "[e.CreateRepostReactionEvent] failed to get conversation repost history")
+			return nil, err
+		}
+
+		err = e.repo.ConversationRepostHistories.Update(&model.ConversationRepostHistories{
+			ID:                   conversationRepostHistory.ID,
+			GuildID:              req.GuildID,
+			OriginChannelID:      req.ChannelID,
+			OriginStartMessageID: conversationRepostHistory.OriginStartMessageID,
+			OriginStopMessageID:  req.MessageID,
+			RepostChannelID:      configConversation.RepostChannelID,
+		})
+		if err != nil {
+			e.log.Fields(logger.Fields{"req": req}).Error(err, "[e.CreateRepostReactionEvent] failed to stop conversation repost")
+			return nil, err
+		}
+		conversationRepostHistory.OriginStopMessageID = req.MessageID
+
+		return conversationRepostHistory, nil
+	}
+
+	return nil, nil
 }
 
 func (e *Entity) CreateRepostReactionEventWithStartStop(req request.MessageReactionRequest, conf model.GuildConfigRepostReaction) error {

--- a/pkg/entities/configs_test.go
+++ b/pkg/entities/configs_test.go
@@ -1016,7 +1016,8 @@ func TestEntity_ConfigRepostReaction(t *testing.T) {
 		GuildID:         "552427722551459840",
 		Emoji:           "test",
 		Quantity:        1,
-		RepostChannelID: "test"}).Return(nil).AnyTimes()
+		RepostChannelID: "test",
+		ReactionType:    "message"}).Return(nil).AnyTimes()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &Entity{

--- a/pkg/handler/configs.go
+++ b/pkg/handler/configs.go
@@ -521,6 +521,56 @@ func (h *Handler) ConfigRepostReaction(c *gin.Context) {
 	c.JSON(http.StatusOK, response.CreateResponse(response.ResponseMessage{Message: "OK"}, nil, nil, nil))
 }
 
+// CreateConfigRepostReactionStartStop     godoc
+// @Summary     Config Respost reaction with start stop
+// @Description Config Respost reaction with start stop
+// @Tags        Config
+// @Accept      json
+// @Produce     json
+// @Param       Request  body request.ConfigRepostReactionStartStop true "Config repost reaction start stop request"
+// @Success     200 {object} response.ResponseMessage
+// @Router      /configs/repost-reactions/start-stop [post]
+func (h *Handler) CreateConfigRepostReactionStartStop(c *gin.Context) {
+	var req request.ConfigRepostReactionStartStop
+	if err := c.BindJSON(&req); err != nil {
+		h.log.Fields(logger.Fields{"req": req}).Error(err, "[handler.CreateConfigRepostReactionStartStop] - failed to read JSON")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+
+	if req.GuildID == "" {
+		h.log.Info("[handler.CreateConfigRepostReactionStartStop] - guild id empty")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, errors.New("guild_id is required"), nil))
+		return
+	}
+
+	if req.EmojiStart == "" {
+		h.log.Info("[handler.CreateConfigRepostReactionStartStop] - emoji empty")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, errors.New("emoji is required"), nil))
+		return
+	}
+
+	if req.EmojiStop == "" {
+		h.log.Info("[handler.CreateConfigRepostReactionStartStop] - emoji empty")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, errors.New("emoji is required"), nil))
+		return
+	}
+
+	if req.RepostChannelID == "" {
+		h.log.Info("[handler.CreateConfigRepostReactionStartStop] - channel id empty")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, errors.New("repost_channel_id is required"), nil))
+		return
+	}
+
+	if err := h.entities.CreateConfigRepostReactionStartStop(req); err != nil {
+		h.log.Fields(logger.Fields{"req": req}).Error(err, "[handler.CreateConfigRepostReactionStartStop] - failed to add config repost reaction start stop")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+
+	c.JSON(http.StatusOK, response.CreateResponse(response.ResponseMessage{Message: "OK"}, nil, nil, nil))
+}
+
 // GetReposeReactionConfigs     godoc
 // @Summary     Get Respost reaction configs
 // @Description Get Respost reaction configs

--- a/pkg/handler/testdata/guild_config_repost_reactions/200-exist-guild-config-repost-reaction.json
+++ b/pkg/handler/testdata/guild_config_repost_reactions/200-exist-guild-config-repost-reaction.json
@@ -7,7 +7,8 @@
       "quantity": 1,
       "repost_channel_id": "1022412798585737226",
       "emoji_start": "",
-      "emoji_stop": ""
+      "emoji_stop": "",
+      "reaction_type": ""
     }
   ]
 }

--- a/pkg/handler/testdata/guild_config_repost_reactions/200-exist-guild-config-repost-reaction.json
+++ b/pkg/handler/testdata/guild_config_repost_reactions/200-exist-guild-config-repost-reaction.json
@@ -8,7 +8,7 @@
       "repost_channel_id": "1022412798585737226",
       "emoji_start": "",
       "emoji_stop": "",
-      "reaction_type": ""
+      "reaction_type": "message"
     }
   ]
 }

--- a/pkg/handler/webhook.go
+++ b/pkg/handler/webhook.go
@@ -178,7 +178,26 @@ func (h *Handler) handleMessageReactionAdd(c *gin.Context, data json.RawMessage)
 		return
 	}
 
-	repostMessage, err := h.entities.CreateRepostReactionEvent(req)
+	// starboard repost conversation
+	repostConversation, err := h.entities.CreateRepostConversationReactionEvent(req)
+	if err != nil {
+		h.log.Fields(logger.Fields{"body": req}).Error(err, "[handler.handleMessageReactionAdd] - failed to create repost reaction event")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+	if repostConversation != nil {
+		c.JSON(http.StatusOK, response.CreateResponse(response.RepostReactionEventData{
+			Status:               "OK",
+			RepostChannelID:      repostConversation.RepostChannelID,
+			ReactionType:         "conversation",
+			OriginStartMessageID: repostConversation.OriginStartMessageID,
+			OriginStopMessageID:  repostConversation.OriginStopMessageID,
+		}, nil, nil, nil))
+		return
+	}
+
+	// starboard repost message
+	repostMessage, err := h.entities.CreateRepostMessageReactionEvent(req)
 	if err != nil {
 		h.log.Fields(logger.Fields{"body": req}).Error(err, "[handler.handleMessageReactionAdd] - failed to create repost reaction event")
 		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))

--- a/pkg/model/conversation_repost_histories.go
+++ b/pkg/model/conversation_repost_histories.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ConversationRepostHistories struct {
+	ID                   uuid.NullUUID `json:"id" gorm:"default:uuid_generate_v4()" swaggertype:"string"`
+	GuildID              string        `json:"guild_id"`
+	OriginChannelID      string        `json:"origin_channel_id"`
+	OriginStartMessageID string        `json:"origin_start_message_id"`
+	OriginStopMessageID  string        `json:"origin_stop_message_id"`
+	RepostChannelID      string        `json:"repost_channel_id"`
+	CreatedAt            time.Time     `json:"created_at"`
+}

--- a/pkg/model/guild_config_repostable_reaction.go
+++ b/pkg/model/guild_config_repostable_reaction.go
@@ -12,4 +12,5 @@ type GuildConfigRepostReaction struct {
 	RepostChannelID string        `json:"repost_channel_id"`
 	EmojiStart      string        `json:"emoji_start"`
 	EmojiStop       string        `json:"emoji_stop"`
+	ReactionType    string        `json:"reaction_type"`
 }

--- a/pkg/repo/conversation_repost_histories/pg.go
+++ b/pkg/repo/conversation_repost_histories/pg.go
@@ -32,12 +32,12 @@ func (pg *pg) Upsert(model model.ConversationRepostHistories) error {
 }
 
 func (pg *pg) Update(model *model.ConversationRepostHistories) error {
-	return pg.db.Save(model).Error
+	return pg.db.Model(&model).Where("id = ?", model.ID).Save(model).Error
 }
 
 func (pg *pg) GetByGuildAndChannel(guildID, channelID string) (*model.ConversationRepostHistories, error) {
 	var model model.ConversationRepostHistories
-	err := pg.db.Where("guild_id = ? AND origin_channel_id = ? and origin_start_message_id != '' and (origin_stop_message_id = '') IS NOT FALSE", guildID, channelID).First(&model).Error
+	err := pg.db.Where("guild_id = ? AND origin_channel_id = ? and origin_start_message_id != '' and origin_stop_message_id = ''", guildID, channelID).First(&model).Error
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repo/conversation_repost_histories/pg.go
+++ b/pkg/repo/conversation_repost_histories/pg.go
@@ -1,0 +1,45 @@
+package conversation_repost_histories
+
+import (
+	"github.com/defipod/mochi/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type pg struct {
+	db *gorm.DB
+}
+
+func NewPG(db *gorm.DB) *pg {
+	return &pg{
+		db: db,
+	}
+}
+
+func (pg *pg) Upsert(model model.ConversationRepostHistories) error {
+	tx := pg.db.Begin()
+
+	err := tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "guild_id"}, {Name: "origin_channel_id"}, {Name: "origin_start_message_id"}},
+		UpdateAll: true,
+	}).Create(&model).Error
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit().Error
+}
+
+func (pg *pg) Update(model *model.ConversationRepostHistories) error {
+	return pg.db.Save(model).Error
+}
+
+func (pg *pg) GetByGuildAndChannel(guildID, channelID string) (*model.ConversationRepostHistories, error) {
+	var model model.ConversationRepostHistories
+	err := pg.db.Where("guild_id = ? AND origin_channel_id = ? and origin_start_message_id != '' and (origin_stop_message_id = '') IS NOT FALSE", guildID, channelID).First(&model).Error
+	if err != nil {
+		return nil, err
+	}
+	return &model, nil
+}

--- a/pkg/repo/conversation_repost_histories/store.go
+++ b/pkg/repo/conversation_repost_histories/store.go
@@ -1,0 +1,9 @@
+package conversation_repost_histories
+
+import "github.com/defipod/mochi/pkg/model"
+
+type Store interface {
+	Upsert(model model.ConversationRepostHistories) error
+	Update(model *model.ConversationRepostHistories) error
+	GetByGuildAndChannel(guildID, channelID string) (*model.ConversationRepostHistories, error)
+}

--- a/pkg/repo/guild_config_repost_reaction/mocks/store.go
+++ b/pkg/repo/guild_config_repost_reaction/mocks/store.go
@@ -78,6 +78,21 @@ func (mr *MockStoreMockRecorder) GetByReaction(guildID, reaction interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByReaction", reflect.TypeOf((*MockStore)(nil).GetByReaction), guildID, reaction)
 }
 
+// GetByReactionConversationStartOrStop mocks base method.
+func (m *MockStore) GetByReactionConversationStartOrStop(guildID, emoji string) (model.GuildConfigRepostReaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByReactionConversationStartOrStop", guildID, emoji)
+	ret0, _ := ret[0].(model.GuildConfigRepostReaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByReactionConversationStartOrStop indicates an expected call of GetByReactionConversationStartOrStop.
+func (mr *MockStoreMockRecorder) GetByReactionConversationStartOrStop(guildID, emoji interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByReactionConversationStartOrStop", reflect.TypeOf((*MockStore)(nil).GetByReactionConversationStartOrStop), guildID, emoji)
+}
+
 // GetByReactionStartOrStop mocks base method.
 func (m *MockStore) GetByReactionStartOrStop(guildID, emoji string) (model.GuildConfigRepostReaction, error) {
 	m.ctrl.T.Helper()

--- a/pkg/repo/guild_config_repost_reaction/pg.go
+++ b/pkg/repo/guild_config_repost_reaction/pg.go
@@ -29,12 +29,17 @@ func (pg *pg) GetByGuildID(guildID string) ([]model.GuildConfigRepostReaction, e
 
 func (pg *pg) GetByReaction(guildID string, emoji string) (model.GuildConfigRepostReaction, error) {
 	var config model.GuildConfigRepostReaction
-	return config, pg.db.Model(model.GuildConfigRepostReaction{}).Where("guild_id = ? AND emoji = ?", guildID, emoji).First(&config).Error
+	return config, pg.db.Model(model.GuildConfigRepostReaction{}).Where("guild_id = ? AND emoji = ? AND reaction_type = ?", guildID, emoji, "message").First(&config).Error
 }
 
 func (pg *pg) GetByReactionStartOrStop(guildID, emoji string) (model.GuildConfigRepostReaction, error) {
 	var config model.GuildConfigRepostReaction
-	return config, pg.db.Model(model.GuildConfigRepostReaction{}).Where("guild_id = ? AND (emoji_start = ? OR emoji_stop = ?)", guildID, emoji, emoji).First(&config).Error
+	return config, pg.db.Model(model.GuildConfigRepostReaction{}).Where("guild_id = ? AND (emoji_start = ? OR emoji_stop = ?) AND reaction_type = ?", guildID, emoji, emoji, "message").First(&config).Error
+}
+
+func (pg *pg) GetByReactionConversationStartOrStop(guildID, emoji string) (model.GuildConfigRepostReaction, error) {
+	var config model.GuildConfigRepostReaction
+	return config, pg.db.Model(model.GuildConfigRepostReaction{}).Where("guild_id = ? AND (emoji_start = ? OR emoji_stop = ?) AND reaction_type = ?", guildID, emoji, emoji, "conversation").First(&config).Error
 }
 
 func (pg *pg) GetByRepostChannelID(guildID, channelID string) (model.GuildConfigRepostReaction, error) {

--- a/pkg/repo/guild_config_repost_reaction/store.go
+++ b/pkg/repo/guild_config_repost_reaction/store.go
@@ -8,6 +8,7 @@ type Store interface {
 	GetByGuildID(guildID string) ([]model.GuildConfigRepostReaction, error)
 	GetByReaction(guildID string, reaction string) (model.GuildConfigRepostReaction, error)
 	GetByReactionStartOrStop(guildID, emoji string) (model.GuildConfigRepostReaction, error)
+	GetByReactionConversationStartOrStop(guildID, emoji string) (model.GuildConfigRepostReaction, error)
 	GetByRepostChannelID(guildID string, channelID string) (model.GuildConfigRepostReaction, error)
 	UpsertOne(config model.GuildConfigRepostReaction) error
 	DeleteOne(guildID string, emoji string) error

--- a/pkg/repo/pg/repo.go
+++ b/pkg/repo/pg/repo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/defipod/mochi/pkg/repo/chain"
 	coingeckosupportedtokens "github.com/defipod/mochi/pkg/repo/coingecko_supported_tokens"
 	configxplevel "github.com/defipod/mochi/pkg/repo/config_xp_level"
+	conversationreposthistories "github.com/defipod/mochi/pkg/repo/conversation_repost_histories"
 	discordguildstatchannels "github.com/defipod/mochi/pkg/repo/discord_guild_stat_channels"
 	discordguildstats "github.com/defipod/mochi/pkg/repo/discord_guild_stats"
 	discordguilds "github.com/defipod/mochi/pkg/repo/discord_guilds"
@@ -131,5 +132,6 @@ func NewRepo(db *gorm.DB) *repo.Repo {
 		QuestReward:                          questreward.NewPG(db),
 		QuestUserReward:                      questuserreward.NewPG(db),
 		QuestUserPass:                        questuserpass.NewPG(db),
+		ConversationRepostHistories:          conversationreposthistories.NewPG(db),
 	}
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/defipod/mochi/pkg/repo/chain"
 	coingeckosupportedtokens "github.com/defipod/mochi/pkg/repo/coingecko_supported_tokens"
 	configxplevel "github.com/defipod/mochi/pkg/repo/config_xp_level"
+	conversationreposthistories "github.com/defipod/mochi/pkg/repo/conversation_repost_histories"
 	discordguildstatchannels "github.com/defipod/mochi/pkg/repo/discord_guild_stat_channels"
 	discordguildstats "github.com/defipod/mochi/pkg/repo/discord_guild_stats"
 	discordguilds "github.com/defipod/mochi/pkg/repo/discord_guilds"
@@ -118,6 +119,7 @@ type Repo struct {
 	ServersUsageStats                    serversusagestats.Store
 	MessageReaction                      messagereaction.Store
 	UserNftWatchlistItem                 usernftwatchlistitem.Store
+	ConversationRepostHistories          conversationreposthistories.Store
 	Quest                                quest.Store
 	QuestRewardType                      questrewardtype.Store
 	QuestUserLog                         questuserlog.Store

--- a/pkg/request/config.go
+++ b/pkg/request/config.go
@@ -109,3 +109,10 @@ type EditMessageRepostRequest struct {
 	RepostChannelID string `json:"repost_channel_id"`
 	RepostMessageID string `json:"repost_message_id"`
 }
+
+type ConfigRepostReactionStartStop struct {
+	GuildID         string `json:"guild_id"`
+	EmojiStart      string `json:"emoji_start"`
+	EmojiStop       string `json:"emoji_stop"`
+	RepostChannelID string `json:"repost_channel_id"`
+}

--- a/pkg/response/message_repost_history.go
+++ b/pkg/response/message_repost_history.go
@@ -5,7 +5,10 @@ type RepostReactionEventResponse struct {
 }
 
 type RepostReactionEventData struct {
-	Status          string `json:"status"`
-	RepostChannelID string `json:"repost_channel_id"`
-	RepostMessageID string `json:"repost_message_id"`
+	Status               string `json:"status"`
+	RepostChannelID      string `json:"repost_channel_id"`
+	RepostMessageID      string `json:"repost_message_id"`
+	ReactionType         string `json:"reaction_type"`
+	OriginStartMessageID string `json:"origin_start_message_id"`
+	OriginStopMessageID  string `json:"origin_stop_message_id"`
 }

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -147,6 +147,7 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 			repostReactionGroup.GET("/:guild_id", h.GetRepostReactionConfigs)
 			repostReactionGroup.POST("", h.ConfigRepostReaction)
 			repostReactionGroup.DELETE("", h.RemoveRepostReactionConfig)
+			repostReactionGroup.POST("/start-stop", h.CreateConfigRepostReactionStartStop)
 			repostReactionGroup.PUT("/message-repost", h.EditMessageRepost)
 		}
 		activitygroup := configGroup.Group("/activities")


### PR DESCRIPTION
- [x] Api for new config `$sb set-start-stop <emoji-start> <emoji-stop> #general`
- [x] Normal starboard will have `reaction_type = "message"` in table `guild_config_repost_reaction` 
- [x] Start stop starboard will have `reaction_type = "conversation"` in table `guild_config_repost_reaction`
- [x] Handle case has config sb start stop
