### PR TITLE
fix: quest issues

### DIFF
--- a/pkg/repo/quest/pg.go
+++ b/pkg/repo/quest/pg.go
@@ -28,6 +28,14 @@ func (pg *pg) List(q ListQuery) ([]model.Quest, error) {
 	if q.Routine != nil {
 		db = db.Where("routine::TEXT = ?", *q.Routine)
 	}
-	db = db.Preload("Rewards").Preload("Rewards.RewardType")
+	if q.Sort == "" {
+		q.Sort = "title"
+	}
+	db = db.Order(q.Sort).Preload("Rewards").Preload("Rewards.RewardType")
 	return quests, db.Find(&quests).Error
+}
+
+func (pg *pg) GetAvailableRoutines() ([]model.QuestRoutine, error) {
+	var routines []model.QuestRoutine
+	return routines, pg.db.Table("quests").Distinct().Pluck("routine", &routines).Error
 }

--- a/pkg/repo/quest/query.go
+++ b/pkg/repo/quest/query.go
@@ -10,4 +10,5 @@ type ListQuery struct {
 	Action    *model.QuestAction
 	NotAction *model.QuestAction
 	Routine   *model.QuestRoutine
+	Sort      string
 }

--- a/pkg/repo/quest/store.go
+++ b/pkg/repo/quest/store.go
@@ -4,4 +4,5 @@ import "github.com/defipod/mochi/pkg/model"
 
 type Store interface {
 	List(q ListQuery) ([]model.Quest, error)
+	GetAvailableRoutines() ([]model.QuestRoutine, error)
 }

--- a/pkg/request/quest.go
+++ b/pkg/request/quest.go
@@ -7,9 +7,8 @@ import (
 )
 
 type GetUserQuestListRequest struct {
-	UserID   string             `json:"user_id" form:"user_id" binding:"required"`
-	Routine  model.QuestRoutine `json:"routine" form:"routine,default=daily"`
-	Quantity int                `json:"quantity" form:"quantity,default=5"`
+	UserID  string             `json:"user_id" form:"user_id" binding:"required"`
+	Routine model.QuestRoutine `json:"routine" form:"routine,default=daily"`
 }
 
 type GenerateUserQuestListRequest struct {

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -290,7 +290,7 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 	questGroup := v1.Group("/quests")
 	{
 		questGroup.GET("", h.GetUserQuestList)
-		questGroup.POST("", h.UpdateQuestProgress)
+		questGroup.POST("/progress", h.UpdateQuestProgress)
 		questGroup.POST("/claim", h.ClaimQuestsRewards)
 	}
 }


### PR DESCRIPTION
**What does this PR do?**
- [x] Unstable order of quests list
- [x] Quest progress is not recorded if user has not run `$quest` before that during that routine
e.g. user said `gm` before run `$quest` => `$quest` returns `GM` quest progress = `0/1`
- [x] Update quest progress API: change `api/v1/quests` to `api/v1/quests/progress`