### PR TITLE
feat: job clean up expired assign contract

### DIFF
--- a/cmd/cleanup-expired-assign-contract/main.go
+++ b/cmd/cleanup-expired-assign-contract/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/defipod/mochi/pkg/config"
+	"github.com/defipod/mochi/pkg/entities"
+	"github.com/defipod/mochi/pkg/job"
+	"github.com/defipod/mochi/pkg/logger"
+	"github.com/defipod/mochi/pkg/service"
+)
+
+func main() {
+	cfg := config.LoadConfig(config.DefaultConfigLoaders())
+	log := logger.NewLogrusLogger()
+	err := entities.Init(cfg, log)
+	if err != nil {
+		log.Fatal(err, "failed to init entities")
+		return
+	}
+
+	svc, err := service.NewService(cfg, log)
+	if err != nil {
+		log.Fatal(err, "service.NewService failed")
+		return
+	}
+
+	log.Info("start job clean up expired assign contract ...")
+	if err := job.NewCleanUpExpiredAssignContractJob(entities.Get(), svc, log).Run(); err != nil {
+		log.Fatal(err, "failed to run job")
+		return
+	}
+
+	log.Info("done")
+}

--- a/migrations/schemas/20220928170237-create-offchain_tip_bot-tables.sql
+++ b/migrations/schemas/20220928170237-create-offchain_tip_bot-tables.sql
@@ -63,6 +63,20 @@ CREATE TABLE IF NOT EXISTS offchain_tip_bot_assign_contract (
   FOREIGN KEY (contract_id) REFERENCES offchain_tip_bot_contracts(id)
 );
 
+CREATE TABLE IF NOT EXISTS offchain_tip_bot_assign_contract_logs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  token_id UUID NOT NULL,
+  chain_id UUID NOT NULL,
+  user_id text NOT NULL,
+  contract_id UUID NOT NULL,
+  status int,
+  expired_time timestamptz,
+  FOREIGN KEY (token_id) REFERENCES offchain_tip_bot_tokens(id),
+  FOREIGN KEY (chain_id) REFERENCES offchain_tip_bot_chains(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (contract_id) REFERENCES offchain_tip_bot_contracts(id)
+);
+
 CREATE TABLE IF NOT EXISTS offchain_tip_bot_user_balances (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   user_id text NOT NULL,

--- a/pkg/entities/offchain_tip_bot_contract.go
+++ b/pkg/entities/offchain_tip_bot_contract.go
@@ -7,3 +7,7 @@ import (
 func (e *Entity) OffchainTipBotCreateAssignContract(ac *model.OffchainTipBotAssignContract) (err error) {
 	return e.repo.OffchainTipBotContract.CreateAssignContract(ac)
 }
+
+func (e *Entity) OffchainTipBotDeleteExpiredAssignContract() (err error) {
+	return e.repo.OffchainTipBotContract.DeleteExpiredAssignContract()
+}

--- a/pkg/job/clean_up_expired_assign_contract.go
+++ b/pkg/job/clean_up_expired_assign_contract.go
@@ -1,0 +1,25 @@
+package job
+
+import (
+	"github.com/defipod/mochi/pkg/entities"
+	"github.com/defipod/mochi/pkg/logger"
+	"github.com/defipod/mochi/pkg/service"
+)
+
+type cleanUpExpiredAssignContract struct {
+	entity  *entities.Entity
+	service *service.Service
+	log     logger.Logger
+}
+
+func NewCleanUpExpiredAssignContractJob(e *entities.Entity, svc *service.Service, l logger.Logger) Job {
+	return &cleanUpExpiredAssignContract{
+		entity:  e,
+		service: svc,
+		log:     l,
+	}
+}
+
+func (job *cleanUpExpiredAssignContract) Run() error {
+	return job.entity.OffchainTipBotDeleteExpiredAssignContract()
+}

--- a/pkg/model/offchain_tip_bot_assign_contract.go
+++ b/pkg/model/offchain_tip_bot_assign_contract.go
@@ -23,16 +23,9 @@ func (OffchainTipBotAssignContract) TableName() string {
 }
 
 func (o *OffchainTipBotAssignContract) BeforeCreate(tx *gorm.DB) (err error) {
-	if err := tx.First(&OffchainTipBotContract{},
-		"id = ? AND assign_status = 1",
-		o.ContractID).Error; err != nil {
+	if err := tx.First(&OffchainTipBotAssignContract{},
+		"token_id = ? AND contract_id = ? AND chain_id = ? AND expired_time > ?", o.TokenID, o.ContractID, o.ChainID, time.Now()).Error; err == nil {
 		return errors.New("contract not found or already assigned")
 	}
 	return nil
-}
-
-func (o *OffchainTipBotAssignContract) AfterCreate(tx *gorm.DB) (err error) {
-	return tx.Model(&OffchainTipBotContract{}).
-		Where("id = ?", o.ContractID).
-		Update("assign_status", 0).Error
 }

--- a/pkg/model/offchain_tip_bot_assign_contract.go
+++ b/pkg/model/offchain_tip_bot_assign_contract.go
@@ -29,3 +29,18 @@ func (o *OffchainTipBotAssignContract) BeforeCreate(tx *gorm.DB) (err error) {
 	}
 	return nil
 }
+
+func (o *OffchainTipBotAssignContract) AfterCreate(tx *gorm.DB) (err error) {
+	if err := tx.Create(&OffchainTipBotAssignContractLog{
+		ID:          o.ID,
+		TokenID:     o.TokenID,
+		ChainID:     o.ChainID,
+		UserID:      o.UserID,
+		ContractID:  o.ContractID,
+		Status:      o.Status,
+		ExpiredTime: o.ExpiredTime,
+	}).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/model/offchain_tip_bot_assign_contract_log.go
+++ b/pkg/model/offchain_tip_bot_assign_contract_log.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type OffchainTipBotAssignContractLog struct {
+	ID          uuid.UUID `json:"id" gorm:"default:uuid_generate_v4()" swaggertype:"string"`
+	TokenID     string    `json:"token_id"`
+	ChainID     string    `json:"chain_id"`
+	UserID      string    `json:"user_id"`
+	ContractID  string    `json:"contract_id"`
+	Status      int       `json:"status" gorm:"default:0"`
+	ExpiredTime time.Time `json:"expired_time"`
+}
+
+func (OffchainTipBotAssignContractLog) TableName() string {
+	return "offchain_tip_bot_assign_contract_logs"
+}

--- a/pkg/repo/offchain_tip_bot_chain/pg.go
+++ b/pkg/repo/offchain_tip_bot_chain/pg.go
@@ -3,7 +3,6 @@ package offchain_tip_bot_chain
 import (
 	"strings"
 
-	"github.com/defipod/mochi/pkg/consts"
 	"github.com/defipod/mochi/pkg/model"
 	"gorm.io/gorm"
 )
@@ -17,9 +16,22 @@ func NewPG(db *gorm.DB) Store {
 }
 
 func (pg *pg) GetAll(f Filter) ([]model.OffchainTipBotChain, error) {
+	var token model.OffchainTipBotToken
+	db := pg.db
+
+	switch {
+	case f.TokenID != "":
+		db = db.Where("token_id = ?", f.TokenID)
+	case f.TokenSymbol != "":
+		db = db.Where("lower(token_symbol) = ?", strings.ToLower(f.TokenSymbol))
+	}
+	if err := db.First(&token).Error; err != nil {
+		return nil, err
+	}
+
 	var rs []model.OffchainTipBotChain
 
-	db := pg.db.
+	db = pg.db.
 		Group("offchain_tip_bot_chains.id,offchain_tip_bot_chains.chain_id").
 		Order("offchain_tip_bot_chains.chain_name").
 		Preload("Tokens").
@@ -27,17 +39,11 @@ func (pg *pg) GetAll(f Filter) ([]model.OffchainTipBotChain, error) {
 		Joins(`
 	JOIN offchain_tip_bot_tokens_chains tc ON tc.chain_id = offchain_tip_bot_chains.id 
 	JOIN offchain_tip_bot_tokens t ON tc.token_id = t.id
-	JOIN offchain_tip_bot_contracts c ON c.chain_id = offchain_tip_bot_chains.id`)
-
-	switch {
-	case f.TokenID != "":
-		db = db.Where("t.token_id = ?", f.TokenID)
-	case f.TokenSymbol != "":
-		db = db.Where("lower(t.token_symbol) = ?", strings.ToLower(f.TokenSymbol))
-	}
+	JOIN offchain_tip_bot_contracts c ON c.chain_id = offchain_tip_bot_chains.id`).
+		Where("t.id = ?", token.ID)
 
 	if f.IsContractAvailable {
-		db = db.Where("c.assign_status = ?", consts.OffchainTipBotContractAssignStatusAvailable)
+		db = db.Where("c.id NOT IN (SELECT id FROM offchain_tip_bot_assign_contract ac WHERE ac.token_id = ? AND expired_time > now())", token.ID)
 	}
 
 	return rs, db.Find(&rs).Error

--- a/pkg/repo/offchain_tip_bot_contract/pg.go
+++ b/pkg/repo/offchain_tip_bot_contract/pg.go
@@ -1,6 +1,8 @@
 package offchain_tip_bot_contract
 
 import (
+	"time"
+
 	"github.com/defipod/mochi/pkg/model"
 	"gorm.io/gorm"
 )
@@ -30,4 +32,8 @@ func (pg *pg) GetByChainID(id string) ([]model.OffchainTipBotContract, error) {
 
 func (pg *pg) CreateAssignContract(ac *model.OffchainTipBotAssignContract) error {
 	return pg.db.Create(ac).Error
+}
+
+func (pg *pg) DeleteExpiredAssignContract() error {
+	return pg.db.Delete(&model.OffchainTipBotAssignContract{}, "expired_time < ?", time.Now()).Error
 }

--- a/pkg/repo/offchain_tip_bot_contract/store.go
+++ b/pkg/repo/offchain_tip_bot_contract/store.go
@@ -7,4 +7,5 @@ type Store interface {
 	GetByAddress(addr string) (model.OffchainTipBotContract, error)
 	GetByChainID(id string) ([]model.OffchainTipBotContract, error)
 	CreateAssignContract(ac *model.OffchainTipBotAssignContract) error
+	DeleteExpiredAssignContract() error
 }


### PR DESCRIPTION
**What does this PR do?**

-   [x] add job to clean up assign contract
- [x] add table offchain_tip_bot_assign_contract_logs
- [x] data from offchain_tip_bot_assign_contract will be cloned to offchain_tip_bot_assign_contract_logs after creating successful 

**How to test**

-   call `/api/v1/offchain-tip-bot/assign-contract` to create an assign contract, check table `offchain_tip_bot_assign_contract`, `offchain_tip_bot_assign_contract_logs`
- run `go run ./cmd/cleanup-expired-assign-contract/main.go` to test job clean up expired assign contract
