### PR TITLE
chore: append list conversation repost config

### DIFF
--- a/migrations/schemas/20221019150033-alter_guild_config_repost_reactions.sql
+++ b/migrations/schemas/20221019150033-alter_guild_config_repost_reactions.sql
@@ -1,0 +1,7 @@
+
+-- +migrate Up
+DROP INDEX guild_config_repost_reactions_emoji_uindex;
+CREATE UNIQUE INDEX guild_config_repost_reactions_emoji_guild_id_uindex on guild_config_repost_reactions (guild_id, emoji, emoji_start, emoji_stop);
+-- +migrate Down
+DROP INDEX guild_config_repost_reactions_emoji_guild_id_uindex;
+CREATE UNIQUE INDEX guild_config_repost_reactions_emoji_uindex ON guild_config_repost_reactions (emoji);

--- a/pkg/repo/guild_config_repost_reaction/pg.go
+++ b/pkg/repo/guild_config_repost_reaction/pg.go
@@ -60,7 +60,7 @@ func (pg *pg) UpsertOne(config model.GuildConfigRepostReaction) error {
 	tx := pg.db.Begin()
 
 	if err := tx.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "emoji"}},
+		Columns:   []clause.Column{{Name: "guild_id"}, {Name: "emoji"}, {Name: "emoji_start"}, {Name: "emoji_stop"}},
 		UpdateAll: true,
 	}).Create(&config).Error; err != nil {
 		tx.Rollback()


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix when set the same emoji in 2 servers discord for reaction message repost, the latest server set will overwrite config with the emoji, so previous server set config with the emoji will disappear.
- [x] Append conversation repost config instead of overwriting

**How to test**
$sb set-chat

**Media (Loom or gif)**
https://www.loom.com/share/8c762aa2be13434bb3161004141d17d3