### PR TITLE
fix: update field trade offers

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6067,10 +6067,7 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
-                "from_address": {
-                    "type": "string"
-                },
-                "from_items": {
+                "have_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.TradeItem"
@@ -6079,17 +6076,17 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
-                "to_address": {
+                "owner_address": {
                     "type": "string"
                 },
-                "to_items": {
+                "updated_at": {
+                    "type": "string"
+                },
+                "want_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.TradeItem"
                     }
-                },
-                "updated_at": {
-                    "type": "string"
                 }
             }
         },
@@ -6469,23 +6466,19 @@ const docTemplate = `{
         "request.CreateTradeOfferRequest": {
             "type": "object",
             "required": [
-                "from_address",
-                "to_address"
+                "owner_address"
             ],
             "properties": {
-                "from_address": {
-                    "type": "string"
-                },
-                "from_items": {
+                "have_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/request.TradeOfferItem"
                     }
                 },
-                "to_address": {
+                "owner_address": {
                     "type": "string"
                 },
-                "to_items": {
+                "want_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/request.TradeOfferItem"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6059,10 +6059,7 @@
                 "created_at": {
                     "type": "string"
                 },
-                "from_address": {
-                    "type": "string"
-                },
-                "from_items": {
+                "have_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.TradeItem"
@@ -6071,17 +6068,17 @@
                 "id": {
                     "type": "string"
                 },
-                "to_address": {
+                "owner_address": {
                     "type": "string"
                 },
-                "to_items": {
+                "updated_at": {
+                    "type": "string"
+                },
+                "want_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.TradeItem"
                     }
-                },
-                "updated_at": {
-                    "type": "string"
                 }
             }
         },
@@ -6461,23 +6458,19 @@
         "request.CreateTradeOfferRequest": {
             "type": "object",
             "required": [
-                "from_address",
-                "to_address"
+                "owner_address"
             ],
             "properties": {
-                "from_address": {
-                    "type": "string"
-                },
-                "from_items": {
+                "have_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/request.TradeOfferItem"
                     }
                 },
-                "to_address": {
+                "owner_address": {
                     "type": "string"
                 },
-                "to_items": {
+                "want_items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/request.TradeOfferItem"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -664,22 +664,20 @@ definitions:
     properties:
       created_at:
         type: string
-      from_address:
-        type: string
-      from_items:
+      have_items:
         items:
           $ref: '#/definitions/model.TradeItem'
         type: array
       id:
         type: string
-      to_address:
+      owner_address:
         type: string
-      to_items:
+      updated_at:
+        type: string
+      want_items:
         items:
           $ref: '#/definitions/model.TradeItem'
         type: array
-      updated_at:
-        type: string
     type: object
   model.UpvoteStreakTier:
     properties:
@@ -924,21 +922,18 @@ definitions:
     type: object
   request.CreateTradeOfferRequest:
     properties:
-      from_address:
-        type: string
-      from_items:
+      have_items:
         items:
           $ref: '#/definitions/request.TradeOfferItem'
         type: array
-      to_address:
+      owner_address:
         type: string
-      to_items:
+      want_items:
         items:
           $ref: '#/definitions/request.TradeOfferItem'
         type: array
     required:
-    - from_address
-    - to_address
+    - owner_address
     type: object
   request.CreateUserRequest:
     properties:

--- a/migrations/schemas/20221026135921-remove-to-address-fields-of-trade-offers-table.sql
+++ b/migrations/schemas/20221026135921-remove-to-address-fields-of-trade-offers-table.sql
@@ -1,0 +1,8 @@
+
+-- +migrate Up
+ALTER TABLE trade_offers DROP COLUMN to_address;
+ALTER TABLE trade_offers RENAME COLUMN from_address TO owner_address;
+
+-- +migrate Down
+ALTER TABLE trade_offers ADD COLUMN IF NOT EXISTS to_address text;
+ALTER TABLE trade_offers RENAME COLUMN owner_address to from_address;

--- a/pkg/entities/trade.go
+++ b/pkg/entities/trade.go
@@ -6,27 +6,26 @@ import (
 )
 
 func (e *Entity) CreateTradeOffer(req request.CreateTradeOfferRequest) (*model.TradeOffer, error) {
-	fromItems := make([]model.TradeItem, 0)
-	for _, item := range req.FromItems {
-		fromItems = append(fromItems, model.TradeItem{
+	haveItems := make([]model.TradeItem, 0)
+	for _, item := range req.HaveItems {
+		haveItems = append(haveItems, model.TradeItem{
 			TokenAddress: item.TokenAddress,
 			TokenIds:     item.TokenIds,
 			IsFrom:       true,
 		})
 	}
 
-	toItems := make([]model.TradeItem, 0)
-	for _, item := range req.ToItems {
-		toItems = append(toItems, model.TradeItem{
+	wantItems := make([]model.TradeItem, 0)
+	for _, item := range req.WantItems {
+		wantItems = append(wantItems, model.TradeItem{
 			TokenAddress: item.TokenAddress,
 			TokenIds:     item.TokenIds,
 		})
 	}
 	offer := &model.TradeOffer{
-		FromAddress: req.FromAddress,
-		ToAddress:   req.ToAddress,
-		FromItems:   fromItems,
-		ToItems:     toItems,
+		OwnerAddress: req.OwnerAddress,
+		HaveItems:    haveItems,
+		WantItems:    wantItems,
 	}
 	return e.repo.TradeOffer.Create(offer)
 }

--- a/pkg/model/trade_offer.go
+++ b/pkg/model/trade_offer.go
@@ -7,13 +7,12 @@ import (
 )
 
 type TradeOffer struct {
-	ID          uuid.UUID   `json:"id" gorm:"default:uuid_generate_v4()" swaggertype:"string"`
-	FromAddress string      `json:"from_address"`
-	ToAddress   string      `json:"to_address"`
-	FromItems   []TradeItem `json:"from_items"`
-	ToItems     []TradeItem `json:"to_items"`
-	CreatedAt   time.Time   `json:"created_at"`
-	UpdatedAt   time.Time   `json:"updated_at"`
+	ID           uuid.UUID   `json:"id" gorm:"default:uuid_generate_v4()" swaggertype:"string"`
+	OwnerAddress string      `json:"owner_address"`
+	HaveItems    []TradeItem `json:"have_items"`
+	WantItems    []TradeItem `json:"want_items"`
+	CreatedAt    time.Time   `json:"created_at"`
+	UpdatedAt    time.Time   `json:"updated_at"`
 }
 
 func (TradeOffer) TableName() string {

--- a/pkg/repo/trade_offer/pg.go
+++ b/pkg/repo/trade_offer/pg.go
@@ -15,7 +15,7 @@ func NewPG(db *gorm.DB) Store {
 
 func (pg *pg) GetOne(id string) (*model.TradeOffer, error) {
 	offer := &model.TradeOffer{}
-	return offer, pg.db.Table("trade_offers").Where("id = ?", id).Preload("FromItems").Preload("ToItems").First(offer).Error
+	return offer, pg.db.Table("trade_offers").Where("id = ?", id).Preload("HaveItems", "is_from = ?", true).Preload("WantItems", "is_from = ?", false).First(offer).Error
 }
 
 func (pg *pg) Create(offer *model.TradeOffer) (*model.TradeOffer, error) {

--- a/pkg/request/trade.go
+++ b/pkg/request/trade.go
@@ -1,13 +1,12 @@
 package request
 
 type CreateTradeOfferRequest struct {
-	FromAddress string           `json:"from_address" form:"from_address" binding:"required"`
-	ToAddress   string           `json:"to_address" form:"to_address" binding:"required"`
-	FromItems   []TradeOfferItem `json:"from_items" form:"form_items"`
-	ToItems     []TradeOfferItem `json:"to_items" form:"to_items"`
+	OwnerAddress string           `json:"owner_address" form:"owner_address" binding:"required"`
+	HaveItems    []TradeOfferItem `json:"have_items" form:"have_items"`
+	WantItems    []TradeOfferItem `json:"want_items" form:"want_items"`
 }
 
 type TradeOfferItem struct {
 	TokenAddress string   `json:"token_address" form:"token_address" binding:"required"`
-	TokenIds     []string `json:"token_ids" form:"token_address" binding:"required"`
+	TokenIds     []string `json:"token_ids" form:"token_ids" binding:"required"`
 }


### PR DESCRIPTION
**What does this PR do?**

- [x] Alter table trade_offers 
    - [x] Remove `to_address` field
    - [x] Rename `from_address` to `owner_address`
- [x] Rename request & response of trade offer  fromItems -> haveItems, toItems -> wantItems 
- [x] Fix get trade offer, preload haveItems and wantItems

**How to test**

- Create
```shell
curl -X 'POST' \
  'http://localhost:8200/api/v1/trades' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "have_items": [
    {
      "token_address": "0x5417A03667AbB6A059b3F174c1F67b1E83753046",
      "token_ids": [
        "1", "2", "3"
      ]
    }
  ],
  "owner_address": "0x5417A03667AbB6A059b3F174c1F67b1E83753046",
  "want_items": [
    {
      "token_address": "0xAEeE56fe367381f29510C27F1Dae815E9591d60a",
      "token_ids": [
        "2", "4"
      ]
    }
  ]
}'
```

- GET
```shell
curl -X 'GET' \
  'http://localhost:8200/api/v1/trades/{created_trade_id}' \
  -H 'accept: application/json'
```
