### PR TITLE
fix: quest - vote streak multiplier

### DIFF
--- a/pkg/repo/quest_streak/pg.go
+++ b/pkg/repo/quest_streak/pg.go
@@ -20,7 +20,17 @@ func (pg *pg) List(q ListQuery) ([]model.QuestStreak, error) {
 		db = db.Where("action = ?", q.Action)
 	}
 	if q.StreakCount != 0 {
-		db = db.Where("streak_from <= ? AND (streak_to IS NULL OR streak_to >= ?)", q.StreakCount, q.StreakCount)
+		db = db.Where(
+			pg.db.Where("streak_from <= ? AND (streak_to IS NULL OR streak_to >= ?)", q.StreakCount, q.StreakCount),
+		).Or(
+			pg.db.Where("? > streak_from AND ? > streak_to", q.StreakCount, q.StreakCount),
+		)
+	}
+	if q.Sort != "" {
+		db = db.Order(q.Sort)
+	}
+	if q.Limit != 0 {
+		db = db.Limit(q.Limit)
 	}
 	return list, db.Find(&list).Error
 }

--- a/pkg/repo/quest_streak/query.go
+++ b/pkg/repo/quest_streak/query.go
@@ -3,4 +3,6 @@ package queststreak
 type ListQuery struct {
 	Action      string
 	StreakCount int
+	Sort        string
+	Limit       int
 }


### PR DESCRIPTION
**What does this PR do?**
Fixed 2 issues
- [x] Start of `lastStreakDate` has to be compared with **START OF YESTERDAY**
- [x] Users with voting streak higher than any streak config will cause multiplier fallback to 1