### PR TITLE
feat: support claim by quest

### DIFF
--- a/pkg/entities/quest.go
+++ b/pkg/entities/quest.go
@@ -292,6 +292,7 @@ func (e *Entity) ClaimQuestsRewards(req request.ClaimQuestsRewardsRequest) (*res
 		Routine:     &req.Routine,
 		IsCompleted: &completed,
 		IsClaimed:   &claimed,
+		QuestID:     req.QuestID,
 	}
 	list, err := e.repo.QuestUserList.List(listQ)
 	if err != nil {

--- a/pkg/repo/quest_streak/pg.go
+++ b/pkg/repo/quest_streak/pg.go
@@ -19,13 +19,11 @@ func (pg *pg) List(q ListQuery) ([]model.QuestStreak, error) {
 	if q.Action != "" {
 		db = db.Where("action = ?", q.Action)
 	}
-	if q.StreakCount != 0 {
-		db = db.Where(
-			pg.db.Where("streak_from <= ? AND (streak_to IS NULL OR streak_to >= ?)", q.StreakCount, q.StreakCount),
-		).Or(
-			pg.db.Where("? > streak_from AND ? > streak_to", q.StreakCount, q.StreakCount),
-		)
-	}
+	db = db.Where(
+		pg.db.Where("streak_from <= ? AND (streak_to IS NULL OR streak_to >= ?)", q.StreakCount, q.StreakCount),
+	).Or(
+		pg.db.Where("? > streak_from AND ? > streak_to", q.StreakCount, q.StreakCount),
+	)
 	if q.Sort != "" {
 		db = db.Order(q.Sort)
 	}

--- a/pkg/request/quest.go
+++ b/pkg/request/quest.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/defipod/mochi/pkg/model"
+	"github.com/google/uuid"
 )
 
 type GetUserQuestListRequest struct {
@@ -19,6 +20,7 @@ type GenerateUserQuestListRequest struct {
 }
 
 type ClaimQuestsRewardsRequest struct {
+	QuestID *uuid.UUID         `json:"quest_id"`
 	UserID  string             `json:"user_id"`
 	Routine model.QuestRoutine `json:"routine"`
 }


### PR DESCRIPTION
**What does this PR do?**
-   [x] Update claim quest rewards API `[POST] /api/v1/quests/claim`: allow to claim rewards by quest_id

**How to test**
```
curl --location --request POST 'http://localhost:8200/api/v1/quests/claim' \
--header 'Content-Type: application/json' \
--data-raw '{
    "user_id": "760874365037314100",
    "routine": "daily",
    "quest_id": "7d767919-38e1-4d81-aad9-3815f8fa8547"
}'
```
