### PR TITLE
feat: notify complete nft sync

### DIFF
--- a/migrations/schemas/20221207153722-add_nft_add_request_history.sql
+++ b/migrations/schemas/20221207153722-add_nft_add_request_history.sql
@@ -1,0 +1,15 @@
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS nft_add_request_histories (
+	id SERIAL NOT NULL PRIMARY KEY,
+	address TEXT NOT NULL,
+	chain_id INTEGER NOT NULL,
+	guild_id TEXT NOT NULL,
+	channel_id TEXT NOT NULL,
+	message_id TEXT NOT NULL UNIQUE,
+	created_at timestamp DEFAULT now(),
+	UNIQUE (address, chain_id)
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS nft_add_request_histories;

--- a/pkg/entities/data_webhook.go
+++ b/pkg/entities/data_webhook.go
@@ -3,37 +3,92 @@ package entities
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/defipod/mochi/pkg/logger"
+	nftaddrequesthistory "github.com/defipod/mochi/pkg/repo/nft_add_request_history"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/util"
 )
 
-func (e *Entity) NotifyNftCollectionIntegration(req request.SendCollectionIntegrationLogsRequest) error {
+func (e *Entity) NotifyNftCollectionIntegration(req request.NotifyCompleteNftIntegrationRequest) error {
 	collection, err := e.repo.NFTCollection.GetByAddress(req.CollectionAddress)
 	if err != nil {
 		e.log.Error(err, "[entity.SendCollectionIntegrationToMochiLogs] repo.NFTCollection.GetByAddress() failed")
 		return err
 	}
+	history, err := e.repo.NftAddRequestHistory.GetOne(nftaddrequesthistory.GetOneQuery{Address: req.CollectionAddress, ChainID: req.ChainID})
+	if err != nil {
+		e.log.Fields(logger.Fields{"address": req.CollectionAddress}).Error(err, "[entity.SendCollectionIntegrationToMochiLogs] repo.NftAddRequestHistory.GetOne() failed")
+		return err
+	}
+
 	chain := strings.ToUpper(util.ConvertChainIDToChain(collection.ChainID))
 	// send logs to mochi
-	err = e.svc.Discord.NotifyCompleteCollectionIntegration(req.GuildID, collection.Name, collection.Symbol, chain, collection.Image)
+	err = e.svc.Discord.NotifyCompleteCollectionIntegration(history.GuildID, collection.Name, collection.Symbol, chain, collection.Image)
 	if err != nil {
 		e.log.Error(err, "[entity.SendCollectionIntegrationToMochiLogs] svc.Discord.NotifyCompleteCollectionIntegration() failed")
 		return err
 	}
 
 	// reply to orignal command
-	_, err = e.discord.ChannelMessageSendEmbedReply(req.ChannelID, &discordgo.MessageEmbed{
-		Title:       fmt.Sprintf("Collection %s has been integrated successfully", collection.Name),
-		Description: fmt.Sprintf("Symbol: %s\nChain: %s", collection.Symbol, chain),
+	description := fmt.Sprintf("👉 Your collection is being processed. We will let you know when it's ready to use.\n👉 To track other collection in `$nft list`, run `$nft %s <token_id>`", collection.Address)
+	_, err = e.discord.ChannelMessageSendEmbedReply(history.ChannelID, &discordgo.MessageEmbed{
+		Author: &discordgo.MessageEmbedAuthor{
+			IconURL: "https://cdn.discordapp.com/emojis/977508805011181638.png?size=240&quality=lossless",
+			Name:    fmt.Sprintf("%s has been added", collection.Name),
+		},
+		Description: description,
 		Thumbnail: &discordgo.MessageEmbedThumbnail{
 			URL: collection.Image,
 		},
+		Timestamp: time.Now().Format("2006-01-02T15:04:05Z07:00"),
 	}, &discordgo.MessageReference{
-		GuildID:   req.GuildID,
-		ChannelID: req.ChannelID,
-		MessageID: req.MessageID,
+		GuildID:   history.GuildID,
+		ChannelID: history.ChannelID,
+		MessageID: history.MessageID,
+	})
+
+	return err
+}
+
+func (e *Entity) NotifyNftCollectionSync(req request.NotifyCompleteNftSyncRequest) error {
+	collection, err := e.repo.NFTCollection.GetByAddress(req.CollectionAddress)
+	if err != nil {
+		e.log.Error(err, "[entity.NotifyNftCollectionSync] repo.NFTCollection.GetByAddress() failed")
+		return err
+	}
+	history, err := e.repo.NftAddRequestHistory.GetOne(nftaddrequesthistory.GetOneQuery{Address: req.CollectionAddress, ChainID: req.ChainID})
+	if err != nil {
+		e.log.Fields(logger.Fields{"address": req.CollectionAddress}).Error(err, "[entity.NotifyNftCollectionSync] repo.NftAddRequestHistory.GetOne() failed")
+		return err
+	}
+
+	chain := strings.ToUpper(util.ConvertChainIDToChain(collection.ChainID))
+	// send logs to mochi
+	err = e.svc.Discord.NotifyCompleteCollectionSync(history.GuildID, collection.Name, collection.Symbol, chain, collection.Image)
+	if err != nil {
+		e.log.Error(err, "[entity.NotifyNftCollectionSync] svc.Discord.NotifyCompleteCollectionSync() failed")
+		return err
+	}
+
+	// reply to orignal command
+	description := fmt.Sprintf("👉 To check rarity, run `$nft %s <token_id>`.\n👉 To track sales, run `$sales track <channel> %s %s`.", collection.Symbol, collection.Address, collection.ChainID)
+	_, err = e.discord.ChannelMessageSendEmbedReply(history.ChannelID, &discordgo.MessageEmbed{
+		Author: &discordgo.MessageEmbedAuthor{
+			IconURL: "https://cdn.discordapp.com/emojis/977508805011181638.png?size=240&quality=lossless",
+			Name:    fmt.Sprintf("%s is ready to use", collection.Name),
+		},
+		Description: description,
+		Thumbnail: &discordgo.MessageEmbedThumbnail{
+			URL: collection.Image,
+		},
+		Timestamp: time.Now().Format("2006-01-02T15:04:05Z07:00"),
+	}, &discordgo.MessageReference{
+		GuildID:   history.GuildID,
+		ChannelID: history.ChannelID,
+		MessageID: history.MessageID,
 	})
 
 	return err

--- a/pkg/entities/nfts.go
+++ b/pkg/entities/nfts.go
@@ -373,8 +373,6 @@ func (e *Entity) CreateSolanaNFTCollection(req request.CreateNFTCollectionReques
 		ChainID:   0,
 		Name:      solanaCollection.Data.Data.Collection,
 		Symbol:    solanaCollection.Data.Data.Symbol,
-		GuildID:   req.GuildID,
-		ChannelID: req.ChannelID,
 		MessageID: req.MessageID,
 	})
 	if err != nil {
@@ -463,14 +461,25 @@ func (e *Entity) CreateEVMNFTCollection(req request.CreateNFTCollectionRequest) 
 		}
 	}
 
-	err = e.indexer.CreateERC721Contract(indexer.CreateERC721ContractRequest{
-		Address:   req.Address,
-		ChainID:   chainID,
-		Name:      name,
-		Symbol:    symbol,
+	// store nft add request
+	history := model.NftAddRequestHistory{
+		Address:   address,
+		ChainID:   int64(chainID),
 		GuildID:   req.GuildID,
 		ChannelID: req.ChannelID,
 		MessageID: req.MessageID,
+	}
+	err = e.repo.NftAddRequestHistory.UpsertOne(history)
+	if err != nil {
+		e.log.Errorf(err, "[CreateERC721Contract] repo.NftAddRequestHistory.UpsertOne() failed")
+		return nil, fmt.Errorf("Failed to create erc721 contract: %v", err)
+	}
+
+	err = e.indexer.CreateERC721Contract(indexer.CreateERC721ContractRequest{
+		Address: req.Address,
+		ChainID: chainID,
+		Name:    name,
+		Symbol:  symbol,
 	})
 	if err != nil {
 		e.log.Errorf(err, "[CreateERC721Contract] failed to create erc721 contract: %v", err)

--- a/pkg/entities/nfts_test.go
+++ b/pkg/entities/nfts_test.go
@@ -1045,7 +1045,7 @@ func TestEntity_CreateNFTCollection(t *testing.T) {
 	//---collection not existed so skip sync check
 	//---convert chain to chain id
 	mockAbi.EXPECT().GetNameAndSymbol("0x7D1070fdbF0eF8752a9627a79b00221b53F231fA", int64(250)).Return("Cyber Rabby", "rabby", nil).AnyTimes()
-	mockIndexer.EXPECT().CreateERC721Contract(indexer.CreateERC721ContractRequest{Address: "0x7D1070fdbF0eF8752a9627a79b00221b53F231fA", ChainID: 250, Name: "Cyber Rabby", Symbol: "rabby", GuildID: "863278424433229854"}).Return(nil).AnyTimes()
+	mockIndexer.EXPECT().CreateERC721Contract(indexer.CreateERC721ContractRequest{Address: "0x7D1070fdbF0eF8752a9627a79b00221b53F231fA", ChainID: 250, Name: "Cyber Rabby", Symbol: "rabby"}).Return(nil).AnyTimes()
 	mockMarketplace.EXPECT().GetCollectionFromPaintswap("0x7D1070fdbF0eF8752a9627a79b00221b53F231fA").Return(paintswapCollection, nil) //marketplace call for get image
 	nftCollection.EXPECT().Create(validCollection).Return(&returnedValidCollection, nil).AnyTimes()
 	mockDiscord.EXPECT().NotifyAddNewCollection("863278424433229854", "Cyber Rabby", "rabby", "ftm", "").Return(nil).AnyTimes()

--- a/pkg/handler/data_webhook.go
+++ b/pkg/handler/data_webhook.go
@@ -9,11 +9,35 @@ import (
 )
 
 func (h *Handler) NotifyNftCollectionIntegration(c *gin.Context) {
-	req := request.SendCollectionIntegrationLogsRequest{}
+	req := request.NotifyCompleteNftIntegrationRequest{}
 	if err := c.BindJSON(&req); err != nil {
-		h.log.Error(err, "[handler.SendCollectionIntegrationLogs] c.BindJSON() failed")
+		h.log.Error(err, "[handler.NotifyNftCollectionIntegration] c.BindJSON() failed")
 		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, err, nil))
 		return
 	}
-	h.entities.NotifyNftCollectionIntegration(req)
+
+	err := h.entities.NotifyNftCollectionIntegration(req)
+	if err != nil {
+		h.log.Error(err, "[handler.NotifyNftCollectionIntegration] entity.NotifyNftCollectionIntegration() failed")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+	c.JSON(http.StatusOK, response.ResponseMessage{Message: "ok"})
+}
+
+func (h *Handler) NotifyNftCollectionSync(c *gin.Context) {
+	req := request.NotifyCompleteNftSyncRequest{}
+	if err := c.BindJSON(&req); err != nil {
+		h.log.Error(err, "[handler.NotifyNftCollectionSync] c.BindJSON() failed")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+
+	err := h.entities.NotifyNftCollectionSync(req)
+	if err != nil {
+		h.log.Error(err, "[handler.NotifyNftCollectionSync] entity.NotifyNftCollectionSync() failed")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+	c.JSON(http.StatusOK, response.ResponseMessage{Message: "ok"})
 }

--- a/pkg/handler/nfts_test.go
+++ b/pkg/handler/nfts_test.go
@@ -276,11 +276,12 @@ func TestHandler_CreateNFTCollection(t *testing.T) {
 		{
 			name: "create new collection successful - with address",
 			req: request.CreateNFTCollectionRequest{
-				Address: "0x7D1070fdbF0eF8752a9627a79b00221b53F231fA",
-				ChainID: "eth",
-				Chain:   "1",
-				Author:  "319132138849173505",
-				GuildID: "863278424433229854",
+				Address:   "0x7D1070fdbF0eF8752a9627a79b00221b53F231fA",
+				ChainID:   "eth",
+				Chain:     "1",
+				Author:    "319132138849173505",
+				GuildID:   "863278424433229854",
+				MessageID: "1050355847173259294",
 			},
 			collectionExist:        false,
 			address:                "0x7D1070fdbF0eF8752a9627a79b00221b53F231fA",
@@ -295,11 +296,12 @@ func TestHandler_CreateNFTCollection(t *testing.T) {
 		{
 			name: "create new collection successful - with market link",
 			req: request.CreateNFTCollectionRequest{
-				Address: "https://opensea.io/collection/cyber-rabby",
-				ChainID: "eth",
-				Chain:   "1",
-				Author:  "319132138849173505",
-				GuildID: "863278424433229854",
+				Address:   "https://opensea.io/collection/cyber-rabby",
+				ChainID:   "eth",
+				Chain:     "1",
+				Author:    "319132138849173505",
+				GuildID:   "863278424433229854",
+				MessageID: "1050355845600382976",
 			},
 			collectionExist:        false,
 			address:                "0x7D1070fdbF0eF8752a9627a79b00221b53F231fA",
@@ -314,11 +316,12 @@ func TestHandler_CreateNFTCollection(t *testing.T) {
 		{
 			name: "fail to create - nft existed - not synced",
 			req: request.CreateNFTCollectionRequest{
-				Address: "0x7aCeE5D0acC520faB33b3Ea25D4FEEF1FfebDE73",
-				ChainID: "eth",
-				Chain:   "1",
-				Author:  "319132138849173505",
-				GuildID: "863278424433229854",
+				Address:   "0x7aCeE5D0acC520faB33b3Ea25D4FEEF1FfebDE73",
+				ChainID:   "eth",
+				Chain:     "1",
+				Author:    "319132138849173505",
+				GuildID:   "863278424433229854",
+				MessageID: "1050355667854180352",
 			},
 			collectionExist: true,
 			address:         "0x7aCeE5D0acC520faB33b3Ea25D4FEEF1FfebDE73",
@@ -332,11 +335,12 @@ func TestHandler_CreateNFTCollection(t *testing.T) {
 		{
 			name: "fail to create - nft existed - already synced",
 			req: request.CreateNFTCollectionRequest{
-				Address: "0x09E0dF4aE51111CA27d6B85708CFB3f1F7cAE982",
-				ChainID: "eth",
-				Chain:   "1",
-				Author:  "319132138849173505",
-				GuildID: "863278424433229854",
+				Address:   "0x09E0dF4aE51111CA27d6B85708CFB3f1F7cAE982",
+				ChainID:   "eth",
+				Chain:     "1",
+				Author:    "319132138849173505",
+				GuildID:   "863278424433229854",
+				MessageID: "1050355039966867456",
 			},
 			collectionExist: true,
 			address:         "0x09E0dF4aE51111CA27d6B85708CFB3f1F7cAE982",
@@ -389,7 +393,6 @@ func TestHandler_CreateNFTCollection(t *testing.T) {
 				ChainID: chainId,
 				Name:    "Cyber Rabby",
 				Symbol:  "RABBY",
-				GuildID: tt.req.GuildID,
 			}).Return(nil).AnyTimes()
 
 			discordMock.EXPECT().NotifyAddNewCollection(tt.req.GuildID, tt.wantName, tt.wantSymbol, tt.req.ChainID, tt.wantImage).AnyTimes()

--- a/pkg/model/nft_add_request_history.go
+++ b/pkg/model/nft_add_request_history.go
@@ -1,0 +1,12 @@
+package model
+
+import "time"
+
+type NftAddRequestHistory struct {
+	Address   string    `json:"address"`
+	ChainID   int64     `json:"chain_id"`
+	GuildID   string    `json:"guild_id"`
+	ChannelID string    `json:"channel_id"`
+	MessageID string    `json:"message_id"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/pkg/repo/nft_add_request_history/pg.go
+++ b/pkg/repo/nft_add_request_history/pg.go
@@ -1,0 +1,33 @@
+package nftaddrequesthistory
+
+import (
+	"github.com/defipod/mochi/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type pg struct {
+	db *gorm.DB
+}
+
+func NewPG(db *gorm.DB) Store {
+	return &pg{db: db}
+}
+
+func (pg *pg) GetOne(q GetOneQuery) (*model.NftAddRequestHistory, error) {
+	result := &model.NftAddRequestHistory{}
+	return result, pg.db.Where("address = ? AND chain_id = ?", q.Address, q.ChainID).First(result).Error
+}
+
+func (pg *pg) UpsertOne(model model.NftAddRequestHistory) error {
+	tx := pg.db.Begin()
+	err := tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "address"}, {Name: "chain_id"}},
+		DoNothing: true,
+	}).Create(&model).Error
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit().Error
+}

--- a/pkg/repo/nft_add_request_history/query.go
+++ b/pkg/repo/nft_add_request_history/query.go
@@ -1,0 +1,6 @@
+package nftaddrequesthistory
+
+type GetOneQuery struct {
+	Address string
+	ChainID int64
+}

--- a/pkg/repo/nft_add_request_history/store.go
+++ b/pkg/repo/nft_add_request_history/store.go
@@ -1,0 +1,8 @@
+package nftaddrequesthistory
+
+import "github.com/defipod/mochi/pkg/model"
+
+type Store interface {
+	GetOne(GetOneQuery) (*model.NftAddRequestHistory, error)
+	UpsertOne(model.NftAddRequestHistory) error
+}

--- a/pkg/repo/pg/repo.go
+++ b/pkg/repo/pg/repo.go
@@ -52,6 +52,7 @@ import (
 	messagereposthistory "github.com/defipod/mochi/pkg/repo/message_repost_history"
 	mochinftsales "github.com/defipod/mochi/pkg/repo/mochi_nft_sales"
 	monikerconfig "github.com/defipod/mochi/pkg/repo/moniker_config"
+	nftaddrequesthistory "github.com/defipod/mochi/pkg/repo/nft_add_request_history"
 	nftcollection "github.com/defipod/mochi/pkg/repo/nft_collection"
 	nftsalestracker "github.com/defipod/mochi/pkg/repo/nft_sales_tracker"
 	offchaintipbotactivitylogs "github.com/defipod/mochi/pkg/repo/offchain_tip_bot_activity_logs"
@@ -171,5 +172,6 @@ func NewRepo(db *gorm.DB) *repo.Repo {
 		GuildConfigTwitterBlacklist:          guildconfigtwitterblacklist.NewPG(db),
 		MonikerConfig:                        monikerconfig.NewPG(db),
 		OffchainTipBotConfigNotify:           offchaintipbotconfignotify.NewPG(db),
+		NftAddRequestHistory:                 nftaddrequesthistory.NewPG(db),
 	}
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -49,6 +49,7 @@ import (
 	messagereposthistory "github.com/defipod/mochi/pkg/repo/message_repost_history"
 	mochinftsales "github.com/defipod/mochi/pkg/repo/mochi_nft_sales"
 	monikerconfig "github.com/defipod/mochi/pkg/repo/moniker_config"
+	nftaddrequesthistory "github.com/defipod/mochi/pkg/repo/nft_add_request_history"
 	nftcollection "github.com/defipod/mochi/pkg/repo/nft_collection"
 	nftsalestracker "github.com/defipod/mochi/pkg/repo/nft_sales_tracker"
 	offchaintipbotactivitylogs "github.com/defipod/mochi/pkg/repo/offchain_tip_bot_activity_logs"
@@ -166,4 +167,5 @@ type Repo struct {
 	OffchainTipBotTransferHistories      offchaintipbottransferhistories.Store
 	MonikerConfig                        monikerconfig.Store
 	OffchainTipBotConfigNotify           offchaintipbotconfignotify.Store
+	NftAddRequestHistory                 nftaddrequesthistory.Store
 }

--- a/pkg/request/data_webhook.go
+++ b/pkg/request/data_webhook.go
@@ -1,8 +1,11 @@
 package request
 
-type SendCollectionIntegrationLogsRequest struct {
-	GuildID           string `json:"guild_id"`
-	ChannelID         string `json:"channel_id"`
-	MessageID         string `json:"message_id"`
+type NotifyCompleteNftIntegrationRequest struct {
 	CollectionAddress string `json:"collection_address"`
+	ChainID           int64  `json:"chain_id"`
+}
+
+type NotifyCompleteNftSyncRequest struct {
+	CollectionAddress string `json:"collection_address"`
+	ChainID           int64  `json:"chain_id"`
 }

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -382,5 +382,6 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 	dataWebhookGroup := v1.Group("/data-webhook")
 	{
 		dataWebhookGroup.POST("/notify-nft-integration", h.NotifyNftCollectionIntegration)
+		dataWebhookGroup.POST("/notify-nft-sync", h.NotifyNftCollectionSync)
 	}
 }

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -501,12 +501,13 @@ func (d *Discord) NotifyCompleteCollectionIntegration(guildID string, collection
 	// get guild info
 	guild, err := d.session.Guild(guildID)
 	if err != nil {
-		return fmt.Errorf("failed to get guild info: %w", err)
+		d.log.Fields(logger.Fields{"guildID": guildID}).Error(err, "[discord.NotifyCompleteCollectionIntegration] d.session.Guild() failed")
+		return err
 	}
 
 	msgEmbed := discordgo.MessageEmbed{
-		Title:       fmt.Sprintf("Collection %s has been completely integration", collectionName),
-		Description: fmt.Sprintf("**Guild: ** %s\n**Symbol: ** %s\n**Chain: ** %s", guild.Name, symbol, chain),
+		Title:       fmt.Sprintf("Collection %s integrated", collectionName),
+		Description: fmt.Sprintf("**Guild: ** `%s`\n**Symbol: ** `%s`\n**Chain: ** `%s`", guild.Name, symbol, chain),
 		Color:       mochiLogColor,
 		Thumbnail: &discordgo.MessageEmbedThumbnail{
 			URL: image,
@@ -516,8 +517,32 @@ func (d *Discord) NotifyCompleteCollectionIntegration(guildID string, collection
 
 	_, err = d.session.ChannelMessageSendEmbed(d.mochiLogChannelID, &msgEmbed)
 	if err != nil {
-		return fmt.Errorf("failed to send message: %w", err)
+		d.log.Error(err, "[discord.NotifyCompleteCollectionIntegration] d.session.ChannelMessageSendEmbed() failed")
+	}
+	return err
+}
+
+func (d *Discord) NotifyCompleteCollectionSync(guildID string, collectionName string, symbol string, chain string, image string) error {
+	// get guild info
+	guild, err := d.session.Guild(guildID)
+	if err != nil {
+		d.log.Fields(logger.Fields{"guildID": guildID}).Error(err, "[discord.NotifyCompleteCollectionSync] d.session.Guild() failed")
+		return err
 	}
 
-	return nil
+	msgEmbed := discordgo.MessageEmbed{
+		Title:       fmt.Sprintf("Collection %s synced", collectionName),
+		Description: fmt.Sprintf("**Guild: ** `%s`\n**Symbol: ** `%s`\n**Chain: ** `%s`", guild.Name, symbol, chain),
+		Color:       mochiLogColor,
+		Thumbnail: &discordgo.MessageEmbedThumbnail{
+			URL: image,
+		},
+		Timestamp: time.Now().Format("2006-01-02T15:04:05Z07:00"),
+	}
+
+	_, err = d.session.ChannelMessageSendEmbed(d.mochiLogChannelID, &msgEmbed)
+	if err != nil {
+		d.log.Error(err, "[discord.NotifyCompleteCollectionSync] d.session.ChannelMessageSendEmbed() failed")
+	}
+	return err
 }

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -64,6 +64,20 @@ func (mr *MockServiceMockRecorder) NotifyCompleteCollectionIntegration(guildID, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyCompleteCollectionIntegration", reflect.TypeOf((*MockService)(nil).NotifyCompleteCollectionIntegration), guildID, collectionName, symbol, chain, image)
 }
 
+// NotifyCompleteCollectionSync mocks base method.
+func (m *MockService) NotifyCompleteCollectionSync(guildID, collectionName, symbol, chain, image string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NotifyCompleteCollectionSync", guildID, collectionName, symbol, chain, image)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NotifyCompleteCollectionSync indicates an expected call of NotifyCompleteCollectionSync.
+func (mr *MockServiceMockRecorder) NotifyCompleteCollectionSync(guildID, collectionName, symbol, chain, image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyCompleteCollectionSync", reflect.TypeOf((*MockService)(nil).NotifyCompleteCollectionSync), guildID, collectionName, symbol, chain, image)
+}
+
 // NotifyGmStreak mocks base method.
 func (m *MockService) NotifyGmStreak(channelID, userDiscordID string, streakCount int, podTownXps model.CreateUserTxResponse) error {
 	m.ctrl.T.Helper()

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -12,6 +12,7 @@ type Service interface {
 	NotifyStealFloorPrice(price float64, floor float64, url string, name string, image string) error
 	NotifyStealAveragePrice(price float64, floor float64, url string, name string, image string) error
 	NotifyCompleteCollectionIntegration(guildID string, collectionName string, symbol string, chain string, image string) error
+	NotifyCompleteCollectionSync(guildID string, collectionName string, symbol string, chain string, image string) error
 
 	// moderation logs
 	NotifyNewGuild(newGuildID string, count int) error

--- a/pkg/service/indexer/indexer.go
+++ b/pkg/service/indexer/indexer.go
@@ -20,8 +20,6 @@ type CreateERC721ContractRequest struct {
 	ChainID   int    `json:"chain_id"`
 	Name      string `json:"name"`
 	Symbol    string `json:"symbol"`
-	GuildID   string `json:"guild_id"`
-	ChannelID string `json:"channel_id"`
 	MessageID string `json:"message_id"`
 }
 


### PR DESCRIPTION
**What does this PR do?**
- [x] Store `$nft add` request histories
- [x] Remove redundant fields from request payload `CreateERC721ContractRequest`
- [x] API exposed to data-webhook to send notification when collection sync progress is completed

**Media**
- Mochi logs
<img width="377" alt="ảnh" src="https://user-images.githubusercontent.com/34529672/206422415-98515d6e-da34-47a9-9387-13076e879512.png">

- Reply to original command
<img width="542" alt="ảnh" src="https://user-images.githubusercontent.com/34529672/206480022-f4f4993e-b88a-4c5a-aeef-4d4b03fecc57.png">
