### PR TITLE
feat: proposal internal

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3506,6 +3506,13 @@ const docTemplate = `{
                         "name": "user_discord_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Guild ID",
+                        "name": "guild_id",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -3841,6 +3848,80 @@ const docTemplate = `{
                 }
             }
         },
+        "/data/usage-stats/dao-tracker": {
+            "get": {
+                "description": "Get dao tracker usage across Mochi",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data"
+                ],
+                "summary": "Metric",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "size",
+                        "name": "size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.DaoTrackerSpaceCountResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/data/usage-stats/proposal": {
+            "get": {
+                "description": "Get proposal usage across Mochi",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data"
+                ],
+                "summary": "Metric",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "size",
+                        "name": "size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.GuildProposalUsageResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/defi/chains": {
             "get": {
                 "description": "List All Chain",
@@ -4021,6 +4102,114 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.GetHistoricalMarketChartResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/defi/price-alert": {
+            "get": {
+                "description": "Get user's price alerts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Defi"
+                ],
+                "summary": "Get user's price alerts",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "user_discord_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ListTokenPriceAlertResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Add to user's price alert",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Defi"
+                ],
+                "summary": "Add to user's price alert",
+                "parameters": [
+                    {
+                        "description": "request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.AddTokenPriceAlertRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.AddTokenPriceAlertResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Remove from user's price alerts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Defi"
+                ],
+                "summary": "Remove from user's price alerts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "symbol",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
                         }
                     }
                 }
@@ -7362,6 +7551,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "source": {
+                    "type": "string"
+                },
                 "space": {
                     "type": "string"
                 },
@@ -8727,6 +8919,9 @@ const docTemplate = `{
                 "net_worth": {
                     "type": "number"
                 },
+                "type": {
+                    "type": "string"
+                },
                 "user_id": {
                     "type": "string"
                 }
@@ -8782,6 +8977,38 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.AddTokenPriceAlertRequest": {
+            "type": "object",
+            "properties": {
+                "alert_type": {
+                    "type": "string",
+                    "enum": [
+                        "price_reaches",
+                        "price_rises_above",
+                        "price_drops_to",
+                        "change_is_over",
+                        "change_is_under"
+                    ]
+                },
+                "frequency": {
+                    "type": "string",
+                    "enum": [
+                        "only_once",
+                        "once_a_day",
+                        "always"
+                    ]
+                },
+                "price": {
+                    "type": "number"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "user_discord_id": {
                     "type": "string"
                 }
             }
@@ -9699,6 +9926,7 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "address",
+                "type",
                 "user_id"
             ],
             "properties": {
@@ -9706,6 +9934,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "alias": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 },
                 "user_id": {
@@ -10138,6 +10369,14 @@ const docTemplate = `{
                 }
             }
         },
+        "response.AddTokenPriceAlertResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/response.TokenPriceAlertResponseData"
+                }
+            }
+        },
         "response.AllTipBotTokensResponse": {
             "type": "object",
             "properties": {
@@ -10502,6 +10741,34 @@ const docTemplate = `{
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.GetUserCurrentUpvoteStreakResponse"
+                }
+            }
+        },
+        "response.DaoTrackerSpaceCountData": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "space": {
+                    "type": "string"
+                }
+            }
+        },
+        "response.DaoTrackerSpaceCountResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.DaoTrackerSpaceCountData"
+                    }
+                },
+                "metadata": {
+                    "$ref": "#/definitions/response.PaginationResponse"
                 }
             }
         },
@@ -11619,6 +11886,34 @@ const docTemplate = `{
                 }
             }
         },
+        "response.GuildProposalUsageData": {
+            "type": "object",
+            "properties": {
+                "guild_id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "proposal_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "response.GuildProposalUsageResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.GuildProposalUsageData"
+                    }
+                },
+                "metadata": {
+                    "$ref": "#/definitions/response.PaginationResponse"
+                }
+            }
+        },
         "response.GuildPruneExcludeList": {
             "type": "object",
             "properties": {
@@ -11938,19 +12233,31 @@ const docTemplate = `{
                 "image_cdn": {
                     "type": "string"
                 },
+                "last_sale_at": {
+                    "type": "string"
+                },
                 "last_sale_price": {
                     "$ref": "#/definitions/response.IndexerPrice"
                 },
                 "name": {
                     "type": "string"
                 },
-                "price_change_1d": {
-                    "type": "string"
-                },
                 "price_change_30d": {
                     "type": "string"
                 },
-                "price_change_7d": {
+                "price_change_365d": {
+                    "type": "string"
+                },
+                "price_change_90d": {
+                    "type": "string"
+                },
+                "price_change_percentage_30d": {
+                    "type": "string"
+                },
+                "price_change_percentage_365d": {
+                    "type": "string"
+                },
+                "price_change_percentage_90d": {
                     "type": "string"
                 },
                 "rarity_rank": {
@@ -12199,6 +12506,38 @@ const docTemplate = `{
                 },
                 "success": {
                     "type": "boolean"
+                }
+            }
+        },
+        "response.ListTokenPriceAlertResponse": {
+            "type": "object",
+            "properties": {
+                "alert_type": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "frequency": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "snoozed_to": {
+                    "type": "string"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_discord_id": {
+                    "type": "string"
                 }
             }
         },
@@ -12904,6 +13243,32 @@ const docTemplate = `{
                 },
                 "vote_config": {
                     "$ref": "#/definitions/model.DaoProposalVoteOption"
+                }
+            }
+        },
+        "response.TokenPriceAlertResponseData": {
+            "type": "object",
+            "properties": {
+                "alert_type": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "frequency": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "snoozed_to": {
+                    "type": "string"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "user_discord_id": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3498,6 +3498,13 @@
                         "name": "user_discord_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Guild ID",
+                        "name": "guild_id",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -3833,6 +3840,80 @@
                 }
             }
         },
+        "/data/usage-stats/dao-tracker": {
+            "get": {
+                "description": "Get dao tracker usage across Mochi",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data"
+                ],
+                "summary": "Metric",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "size",
+                        "name": "size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.DaoTrackerSpaceCountResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/data/usage-stats/proposal": {
+            "get": {
+                "description": "Get proposal usage across Mochi",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Data"
+                ],
+                "summary": "Metric",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "size",
+                        "name": "size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.GuildProposalUsageResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/defi/chains": {
             "get": {
                 "description": "List All Chain",
@@ -4013,6 +4094,114 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.GetHistoricalMarketChartResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/defi/price-alert": {
+            "get": {
+                "description": "Get user's price alerts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Defi"
+                ],
+                "summary": "Get user's price alerts",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "user_discord_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ListTokenPriceAlertResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Add to user's price alert",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Defi"
+                ],
+                "summary": "Add to user's price alert",
+                "parameters": [
+                    {
+                        "description": "request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.AddTokenPriceAlertRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.AddTokenPriceAlertResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Remove from user's price alerts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Defi"
+                ],
+                "summary": "Remove from user's price alerts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "symbol",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
                         }
                     }
                 }
@@ -7354,6 +7543,9 @@
                 "id": {
                     "type": "string"
                 },
+                "source": {
+                    "type": "string"
+                },
                 "space": {
                     "type": "string"
                 },
@@ -8719,6 +8911,9 @@
                 "net_worth": {
                     "type": "number"
                 },
+                "type": {
+                    "type": "string"
+                },
                 "user_id": {
                     "type": "string"
                 }
@@ -8774,6 +8969,38 @@
                     "type": "string"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.AddTokenPriceAlertRequest": {
+            "type": "object",
+            "properties": {
+                "alert_type": {
+                    "type": "string",
+                    "enum": [
+                        "price_reaches",
+                        "price_rises_above",
+                        "price_drops_to",
+                        "change_is_over",
+                        "change_is_under"
+                    ]
+                },
+                "frequency": {
+                    "type": "string",
+                    "enum": [
+                        "only_once",
+                        "once_a_day",
+                        "always"
+                    ]
+                },
+                "price": {
+                    "type": "number"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "user_discord_id": {
                     "type": "string"
                 }
             }
@@ -9691,6 +9918,7 @@
             "type": "object",
             "required": [
                 "address",
+                "type",
                 "user_id"
             ],
             "properties": {
@@ -9698,6 +9926,9 @@
                     "type": "string"
                 },
                 "alias": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 },
                 "user_id": {
@@ -10130,6 +10361,14 @@
                 }
             }
         },
+        "response.AddTokenPriceAlertResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/response.TokenPriceAlertResponseData"
+                }
+            }
+        },
         "response.AllTipBotTokensResponse": {
             "type": "object",
             "properties": {
@@ -10494,6 +10733,34 @@
             "properties": {
                 "data": {
                     "$ref": "#/definitions/response.GetUserCurrentUpvoteStreakResponse"
+                }
+            }
+        },
+        "response.DaoTrackerSpaceCountData": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "space": {
+                    "type": "string"
+                }
+            }
+        },
+        "response.DaoTrackerSpaceCountResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.DaoTrackerSpaceCountData"
+                    }
+                },
+                "metadata": {
+                    "$ref": "#/definitions/response.PaginationResponse"
                 }
             }
         },
@@ -11611,6 +11878,34 @@
                 }
             }
         },
+        "response.GuildProposalUsageData": {
+            "type": "object",
+            "properties": {
+                "guild_id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "proposal_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "response.GuildProposalUsageResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.GuildProposalUsageData"
+                    }
+                },
+                "metadata": {
+                    "$ref": "#/definitions/response.PaginationResponse"
+                }
+            }
+        },
         "response.GuildPruneExcludeList": {
             "type": "object",
             "properties": {
@@ -11930,19 +12225,31 @@
                 "image_cdn": {
                     "type": "string"
                 },
+                "last_sale_at": {
+                    "type": "string"
+                },
                 "last_sale_price": {
                     "$ref": "#/definitions/response.IndexerPrice"
                 },
                 "name": {
                     "type": "string"
                 },
-                "price_change_1d": {
-                    "type": "string"
-                },
                 "price_change_30d": {
                     "type": "string"
                 },
-                "price_change_7d": {
+                "price_change_365d": {
+                    "type": "string"
+                },
+                "price_change_90d": {
+                    "type": "string"
+                },
+                "price_change_percentage_30d": {
+                    "type": "string"
+                },
+                "price_change_percentage_365d": {
+                    "type": "string"
+                },
+                "price_change_percentage_90d": {
                     "type": "string"
                 },
                 "rarity_rank": {
@@ -12191,6 +12498,38 @@
                 },
                 "success": {
                     "type": "boolean"
+                }
+            }
+        },
+        "response.ListTokenPriceAlertResponse": {
+            "type": "object",
+            "properties": {
+                "alert_type": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "frequency": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "snoozed_to": {
+                    "type": "string"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_discord_id": {
+                    "type": "string"
                 }
             }
         },
@@ -12896,6 +13235,32 @@
                 },
                 "vote_config": {
                     "$ref": "#/definitions/model.DaoProposalVoteOption"
+                }
+            }
+        },
+        "response.TokenPriceAlertResponseData": {
+            "type": "object",
+            "properties": {
+                "alert_type": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "frequency": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "snoozed_to": {
+                    "type": "string"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "user_discord_id": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -397,6 +397,8 @@ definitions:
         type: string
       id:
         type: string
+      source:
+        type: string
       space:
         type: string
       updated_at:
@@ -1291,6 +1293,8 @@ definitions:
         type: string
       net_worth:
         type: number
+      type:
+        type: string
       user_id:
         type: string
     type: object
@@ -1327,6 +1331,29 @@ definitions:
       symbol:
         type: string
       user_id:
+        type: string
+    type: object
+  request.AddTokenPriceAlertRequest:
+    properties:
+      alert_type:
+        enum:
+        - price_reaches
+        - price_rises_above
+        - price_drops_to
+        - change_is_over
+        - change_is_under
+        type: string
+      frequency:
+        enum:
+        - only_once
+        - once_a_day
+        - always
+        type: string
+      price:
+        type: number
+      symbol:
+        type: string
+      user_discord_id:
         type: string
     type: object
   request.BalcklistChannelRepostConfigRequest:
@@ -1930,10 +1957,13 @@ definitions:
         type: string
       alias:
         type: string
+      type:
+        type: string
       user_id:
         type: string
     required:
     - address
+    - type
     - user_id
     type: object
   request.TradeOfferItem:
@@ -2213,6 +2243,11 @@ definitions:
           $ref: '#/definitions/model.CoingeckoSupportedTokens'
         type: array
     type: object
+  response.AddTokenPriceAlertResponse:
+    properties:
+      data:
+        $ref: '#/definitions/response.TokenPriceAlertResponseData'
+    type: object
   response.AllTipBotTokensResponse:
     properties:
       data:
@@ -2448,6 +2483,24 @@ definitions:
     properties:
       data:
         $ref: '#/definitions/response.GetUserCurrentUpvoteStreakResponse'
+    type: object
+  response.DaoTrackerSpaceCountData:
+    properties:
+      count:
+        type: integer
+      source:
+        type: string
+      space:
+        type: string
+    type: object
+  response.DaoTrackerSpaceCountResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/response.DaoTrackerSpaceCountData'
+        type: array
+      metadata:
+        $ref: '#/definitions/response.PaginationResponse'
     type: object
   response.DataFilterConfigByReaction:
     properties:
@@ -3168,6 +3221,24 @@ definitions:
       updated_at:
         type: string
     type: object
+  response.GuildProposalUsageData:
+    properties:
+      guild_id:
+        type: string
+      is_active:
+        type: boolean
+      proposal_count:
+        type: integer
+    type: object
+  response.GuildProposalUsageResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/response.GuildProposalUsageData'
+        type: array
+      metadata:
+        $ref: '#/definitions/response.PaginationResponse'
+    type: object
   response.GuildPruneExcludeList:
     properties:
       guild_id:
@@ -3377,15 +3448,23 @@ definitions:
         type: string
       image_cdn:
         type: string
+      last_sale_at:
+        type: string
       last_sale_price:
         $ref: '#/definitions/response.IndexerPrice'
       name:
         type: string
-      price_change_1d:
-        type: string
-      price_change_7d:
-        type: string
       price_change_30d:
+        type: string
+      price_change_90d:
+        type: string
+      price_change_365d:
+        type: string
+      price_change_percentage_30d:
+        type: string
+      price_change_percentage_90d:
+        type: string
+      price_change_percentage_365d:
         type: string
       rarity_rank:
         type: integer
@@ -3546,6 +3625,27 @@ definitions:
         type: string
       success:
         type: boolean
+    type: object
+  response.ListTokenPriceAlertResponse:
+    properties:
+      alert_type:
+        type: string
+      created_at:
+        type: string
+      currency:
+        type: string
+      frequency:
+        type: string
+      price:
+        type: number
+      snoozed_to:
+        type: string
+      symbol:
+        type: string
+      updated_at:
+        type: string
+      user_discord_id:
+        type: string
     type: object
   response.LogoutResponse:
     properties:
@@ -4002,6 +4102,23 @@ definitions:
         type: string
       vote_config:
         $ref: '#/definitions/model.DaoProposalVoteOption'
+    type: object
+  response.TokenPriceAlertResponseData:
+    properties:
+      alert_type:
+        type: string
+      currency:
+        type: string
+      frequency:
+        type: string
+      price:
+        type: number
+      snoozed_to:
+        type: string
+      symbol:
+        type: string
+      user_discord_id:
+        type: string
     type: object
   response.TransactionsResponse:
     properties:
@@ -6432,6 +6549,11 @@ paths:
         name: user_discord_id
         required: true
         type: string
+      - description: Guild ID
+        in: query
+        name: guild_id
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -6638,6 +6760,54 @@ paths:
       summary: Metric
       tags:
       - Data
+  /data/usage-stats/dao-tracker:
+    get:
+      consumes:
+      - application/json
+      description: Get dao tracker usage across Mochi
+      parameters:
+      - description: page
+        in: query
+        name: page
+        type: string
+      - description: size
+        in: query
+        name: size
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.DaoTrackerSpaceCountResponse'
+      summary: Metric
+      tags:
+      - Data
+  /data/usage-stats/proposal:
+    get:
+      consumes:
+      - application/json
+      description: Get proposal usage across Mochi
+      parameters:
+      - description: page
+        in: query
+        name: page
+        type: string
+      - description: size
+        in: query
+        name: size
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.GuildProposalUsageResponse'
+      summary: Metric
+      tags:
+      - Data
   /defi/chains:
     get:
       consumes:
@@ -6759,6 +6929,76 @@ paths:
           schema:
             $ref: '#/definitions/response.GetHistoricalMarketChartResponse'
       summary: Get historical market chart
+      tags:
+      - Defi
+  /defi/price-alert:
+    delete:
+      consumes:
+      - application/json
+      description: Remove from user's price alerts
+      parameters:
+      - in: query
+        name: symbol
+        required: true
+        type: string
+      - in: query
+        name: user_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+      summary: Remove from user's price alerts
+      tags:
+      - Defi
+    get:
+      consumes:
+      - application/json
+      description: Get user's price alerts
+      parameters:
+      - in: query
+        name: page
+        type: integer
+      - in: query
+        name: size
+        type: integer
+      - in: query
+        name: user_discord_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.ListTokenPriceAlertResponse'
+      summary: Get user's price alerts
+      tags:
+      - Defi
+    post:
+      consumes:
+      - application/json
+      description: Add to user's price alert
+      parameters:
+      - description: request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/request.AddTokenPriceAlertRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.AddTokenPriceAlertResponse'
+      summary: Add to user's price alert
       tags:
       - Defi
   /defi/token:

--- a/pkg/entities/dao_vote.go
+++ b/pkg/entities/dao_vote.go
@@ -76,6 +76,10 @@ func (e *Entity) GetAllDaoProposalByUserId(userId string) (*[]model.DaoProposal,
 	return proposals, nil
 }
 
+func (e *Entity) GetAllDaoProposalByGuild(guildId string) (*[]model.DaoProposal, error) {
+	return e.repo.DaoProposal.GetAllByGuildId(guildId)
+}
+
 func (e *Entity) GetDaoVotesByUserId(userId string) (*[]model.DaoVote, error) {
 	votes, err := e.repo.DaoVote.GetByUserId(userId)
 	if err != nil {

--- a/pkg/handler/data/data.go
+++ b/pkg/handler/data/data.go
@@ -120,6 +120,16 @@ func (h *Handler) MetricSupportedTokens(c *gin.Context, query string, guildId st
 	c.JSON(http.StatusOK, response.CreateResponse(totalSupportedTokens, nil, nil, nil))
 }
 
+// MetricProposalUsage   godoc
+// @Summary     Metric
+// @Description Get proposal usage across Mochi
+// @Tags        Data
+// @Accept      json
+// @Produce     json
+// @Param       page   query  string false  "page"
+// @Param       size   query  string false  "size"
+// @Success     200 {object} response.GuildProposalUsageResponse
+// @Router      /data/usage-stats/proposal [get]
 func (h *Handler) MetricProposalUsage(c *gin.Context) {
 	page := c.Query("page")
 	size := c.Query("size")
@@ -138,6 +148,16 @@ func (h *Handler) MetricProposalUsage(c *gin.Context) {
 	c.JSON(http.StatusOK, response.CreateResponse(res, nil, nil, nil))
 }
 
+// MetricDaoTracker   godoc
+// @Summary     Metric
+// @Description Get dao tracker usage across Mochi
+// @Tags        Data
+// @Accept      json
+// @Produce     json
+// @Param       page   query  string false  "page"
+// @Param       size   query  string false  "size"
+// @Success     200 {object} response.DaoTrackerSpaceCountResponse
+// @Router      /data/usage-stats/dao-tracker [get]
 func (h *Handler) MetricDaoTracker(c *gin.Context) {
 	page := c.Query("page")
 	size := c.Query("size")

--- a/pkg/handler/data/data.go
+++ b/pkg/handler/data/data.go
@@ -119,3 +119,39 @@ func (h *Handler) MetricSupportedTokens(c *gin.Context, query string, guildId st
 	}
 	c.JSON(http.StatusOK, response.CreateResponse(totalSupportedTokens, nil, nil, nil))
 }
+
+func (h *Handler) MetricProposalUsage(c *gin.Context) {
+	page := c.Query("page")
+	size := c.Query("size")
+	if page == "" {
+		page = "0"
+	}
+	if size == "" {
+		size = "20"
+	}
+	res, err := h.entities.GetProposalUsage(page, size)
+	if err != nil {
+		h.log.Fields(logger.Fields{"page": page, "size": size}).Error(err, "[handler.MetricProposalUsage] - failed to get proposal data")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+	c.JSON(http.StatusOK, response.CreateResponse(res, nil, nil, nil))
+}
+
+func (h *Handler) MetricDaoTracker(c *gin.Context) {
+	page := c.Query("page")
+	size := c.Query("size")
+	if page == "" {
+		page = "0"
+	}
+	if size == "" {
+		size = "20"
+	}
+	res, err := h.entities.GetDaoTrackerMetric(page, size)
+	if err != nil {
+		h.log.Fields(logger.Fields{"page": page, "size": size}).Error(err, "[handler.MetricDaoTracker] - failed to get dao tracker data")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+	c.JSON(http.StatusOK, response.CreateResponse(res, nil, nil, nil))
+}

--- a/pkg/handler/data/interface.go
+++ b/pkg/handler/data/interface.go
@@ -4,6 +4,8 @@ import "github.com/gin-gonic/gin"
 
 type IHandler interface {
 	AddGitbookClick(c *gin.Context)
+	MetricProposalUsage(c *gin.Context)
+	MetricDaoTracker(c *gin.Context)
 	MetricByProperties(c *gin.Context)
 	MetricNftCollection(c *gin.Context, query string)
 	MetricActiveUsers(c *gin.Context, query string, guildId string)

--- a/pkg/handler/defi/defi.go
+++ b/pkg/handler/defi/defi.go
@@ -333,7 +333,7 @@ func (h *Handler) ListAllChain(c *gin.Context) {
 // @Tags        Defi
 // @Accept      json
 // @Produce     json
-// @Param       req body request.AddTokenPriceAlert true "request"
+// @Param       req body request.AddTokenPriceAlertRequest true "request"
 // @Success     200 {object} response.AddTokenPriceAlertResponse
 // @Router      /defi/price-alert [post]
 func (h *Handler) AddTokenPriceAlert(c *gin.Context) {

--- a/pkg/repo/dao_proposal/pg.go
+++ b/pkg/repo/dao_proposal/pg.go
@@ -1,10 +1,15 @@
 package dao_proposal
 
-import "github.com/defipod/mochi/pkg/model"
+import (
+	"github.com/defipod/mochi/pkg/model"
+	"github.com/defipod/mochi/pkg/response"
+)
 
 type Store interface {
 	GetById(id int64) (*model.DaoProposal, error)
+	GetAllWithCount(page int, size int) (*[]response.ProposalCount, error)
 	GetAllByCreatorId(userId string) (*[]model.DaoProposal, error)
+	GetAllByGuildId(guildId string) (*[]model.DaoProposal, error)
 	GetByCreatorIdAndProposalId(proposal int64, userId string) (models []model.DaoProposalWithView, err error)
 	Create(model *model.DaoProposal) (*model.DaoProposal, error)
 	UpdateDiscussionChannel(id int64, discussionChannelId string) error

--- a/pkg/repo/dao_proposal/store.go
+++ b/pkg/repo/dao_proposal/store.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/defipod/mochi/pkg/model"
+	"github.com/defipod/mochi/pkg/response"
 )
 
 type pg struct {
@@ -20,6 +21,13 @@ func (pg *pg) GetById(id int64) (model *model.DaoProposal, err error) {
 
 func (pg *pg) GetAllByCreatorId(userId string) (models *[]model.DaoProposal, err error) {
 	return models, pg.db.Where("creator_id = ?", userId).Find(&models).Error
+}
+func (pg *pg) GetAllWithCount(page int, size int) (models *[]response.ProposalCount, err error) {
+	return models, pg.db.Table("dao_proposal").Select("guild_id, COUNT(guild_id)").Group("guild_id").Offset(size * page).Limit(size).Order("count DESC").Scan(&models).Error
+}
+
+func (pg *pg) GetAllByGuildId(guildId string) (models *[]model.DaoProposal, err error) {
+	return models, pg.db.Where("guild_id = ?", guildId).Find(&models).Error
 }
 func (pg *pg) GetByCreatorIdAndProposalId(proposal int64, userId string) (models []model.DaoProposalWithView, err error) {
 	rows, err := pg.db.Table("dao_proposal").Joins("join view_dao_proposal ON id = ? AND creator_id = ? AND view_dao_proposal.proposal_id = ?", proposal, userId, proposal).Rows()

--- a/pkg/repo/guild_config_dao_tracker/pg.go
+++ b/pkg/repo/guild_config_dao_tracker/pg.go
@@ -1,11 +1,15 @@
 package guild_config_dao_tracker
 
-import "github.com/defipod/mochi/pkg/model"
+import (
+	"github.com/defipod/mochi/pkg/model"
+	"github.com/defipod/mochi/pkg/response"
+)
 
 type Store interface {
 	GetAllByGuildID(guildId string) (*[]model.GuildConfigDaoTracker, error)
 	GetAllBySpace(space string) ([]model.GuildConfigDaoTracker, error)
 	GetAllBySpaceAndSource(space, source string) ([]model.GuildConfigDaoTracker, error)
+	GetAllWithCount(page int, size int) ([]response.DaoTrackerSpaceCountData, error)
 	DeleteByID(id string) error
 	Upsert(model.GuildConfigDaoTracker) error
 }

--- a/pkg/repo/guild_config_dao_tracker/store.go
+++ b/pkg/repo/guild_config_dao_tracker/store.go
@@ -2,6 +2,7 @@ package guild_config_dao_tracker
 
 import (
 	"github.com/defipod/mochi/pkg/model"
+	"github.com/defipod/mochi/pkg/response"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -27,6 +28,10 @@ func (pg *pg) DeleteByID(id string) error {
 	cfg := model.GuildConfigDaoTracker{}
 	return pg.db.Where("id = ?", id).Delete(&cfg).Error
 }
+func (pg *pg) GetAllWithCount(page int, size int) (models []response.DaoTrackerSpaceCountData, err error) {
+	return models, pg.db.Table("guild_config_dao_trackers").Select("space, source, COUNT(space)").Group("space, source").Offset(size * page).Limit(size).Order("count DESC").Scan(&models).Error
+}
+
 func (pg *pg) Upsert(cfg model.GuildConfigDaoTracker) error {
 	tx := pg.db.Begin()
 

--- a/pkg/response/dao_proposal.go
+++ b/pkg/response/dao_proposal.go
@@ -5,3 +5,28 @@ import "github.com/defipod/mochi/pkg/model"
 type CreateDaoProposalResponse struct {
 	Data model.DaoProposal `json:"data"`
 }
+
+type ProposalCount struct {
+	GuildId string `json:"guild_id"`
+	Count   int64  `json:"count"`
+}
+type GuildProposalUsageResponse struct {
+	Pagination PaginationResponse        `json:"metadata"`
+	Data       *[]GuildProposalUsageData `json:"data"`
+}
+
+type GuildProposalUsageData struct {
+	GuildId       string `json:"guild_id"`
+	ProposalCount int64  `json:"proposal_count"`
+	IsActive      bool   `json:"is_active"`
+}
+
+type DaoTrackerSpaceCountResponse struct {
+	Pagination PaginationResponse          `json:"metadata"`
+	Data       *[]DaoTrackerSpaceCountData `json:"data"`
+}
+type DaoTrackerSpaceCountData struct {
+	Space  string `json:"space"`
+	Count  int64  `json:"count"`
+	Source string `json:"source"`
+}

--- a/pkg/response/defi.go
+++ b/pkg/response/defi.go
@@ -213,3 +213,15 @@ type TokenPriceAlertResponseData struct {
 type AddTokenPriceAlertResponse struct {
 	Data *TokenPriceAlertResponseData `json:"data"`
 }
+
+type ListTokenPriceAlertResponse struct {
+	UserDiscordID string               `json:"user_discord_id"`
+	Symbol        string               `json:"symbol"`
+	Currency      string               `json:"currency"`
+	AlertType     model.AlertType      `json:"alert_type"`
+	Frequency     model.AlertFrequency `json:"frequency"`
+	Price         float64              `json:"price"`
+	SnoozedTo     time.Time            `json:"snoozed_to"`
+	CreatedAt     time.Time            `json:"created_at"`
+	UpdatedAt     time.Time            `json:"updated_at"`
+}

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -50,6 +50,8 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 		usageGroup := dataGroup.Group("/usage-stats")
 		{
 			usageGroup.GET("/gitbook", h.Data.AddGitbookClick)
+			usageGroup.GET("/proposal", h.Data.MetricProposalUsage)
+			usageGroup.GET("/dao-tracker", h.Data.MetricDaoTracker)
 		}
 		activitygroup := dataGroup.Group("/activities")
 		{


### PR DESCRIPTION
**What does this PR do?**

- new api to get usage stats for dao tracker and guild dao proposal
- add new query `guild_id` to existing `/api/v1/dao-voting/proposals`
<img width="516" alt="Screenshot 2023-02-20 at 17 04 09" src="https://user-images.githubusercontent.com/84314071/220074522-1bc9e997-4619-4a66-910f-d000c9b82ca6.png">
<img width="534" alt="Screenshot 2023-02-20 at 17 04 54" src="https://user-images.githubusercontent.com/84314071/220074703-81abfe62-64d5-46e7-b80e-62e0b9191709.png">
