### PR TITLE
chore: add workers for price alert system 

### DIFF
--- a/cmd/watch-coin-price-change/main.go
+++ b/cmd/watch-coin-price-change/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/defipod/mochi/pkg/config"
+	"github.com/defipod/mochi/pkg/entities"
+	"github.com/defipod/mochi/pkg/job"
+	"github.com/defipod/mochi/pkg/logger"
+)
+
+func main() {
+	cfg := config.LoadConfig(config.DefaultConfigLoaders())
+	log := logger.NewLogrusLogger()
+	err := entities.Init(cfg, log)
+	if err != nil {
+		log.Fatal(err, "failed to init entities")
+	}
+
+	log.Info("start job watch coin price change ...")
+	if err := job.NewWatchCoinPriceChange(entities.Get(), log).Run(); err != nil {
+		log.Fatal(err, "[NewWatchCoinPriceChange] failed to run job")
+	}
+
+	log.Info("done")
+
+}

--- a/cmd/watch-dm-notify-price-alert/main.go
+++ b/cmd/watch-dm-notify-price-alert/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/defipod/mochi/pkg/config"
+	"github.com/defipod/mochi/pkg/entities"
+	"github.com/defipod/mochi/pkg/job"
+	"github.com/defipod/mochi/pkg/logger"
+)
+
+func main() {
+	cfg := config.LoadConfig(config.DefaultConfigLoaders())
+	log := logger.NewLogrusLogger()
+	err := entities.Init(cfg, log)
+	if err != nil {
+		log.Fatal(err, "failed to init entities")
+	}
+
+	log.Info("start job watch DM notify user's discord ...")
+	if err := job.NewWatchDMNotifyPriceAlert(entities.Get(), log).Run(); err != nil {
+		log.Fatal(err, "[NewWatchDMNotifyPriceAlert] failed to run job")
+	}
+
+	log.Info("done")
+
+}

--- a/migrations/schemas/20230222164928-alter_user_token_price_alert.sql
+++ b/migrations/schemas/20230222164928-alter_user_token_price_alert.sql
@@ -1,0 +1,8 @@
+
+-- +migrate Up
+ALTER TABLE user_token_price_alerts ADD COLUMN IF NOT EXISTS price_by_percent FLOAT8 DEFAULT 0;
+ALTER TABLE user_token_price_alerts RENAME COLUMN price TO value;
+
+-- +migrate Down
+ALTER TABLE user_token_price_alerts DROP COLUMN IF EXISTS price_by_percent;
+ALTER TABLE user_token_price_alerts RENAME COLUMN value TO price;

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -17,6 +17,7 @@ type Cache interface {
 
 	Remove(key string) error
 	ZRemove(key string, value interface{}) error
+	ZRemoveByScore(key, min, max string) error
 	GetString(key string) (string, error)
 	GetStringSorted(key, min, max string) []string
 	GetStringSortedWithScores(key, min, max string) []response.ZSetWithScoreData

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,6 +2,10 @@ package cache
 
 import (
 	"time"
+
+	"github.com/go-redis/redis/v8"
+
+	"github.com/defipod/mochi/pkg/response"
 )
 
 type Cache interface {
@@ -15,9 +19,13 @@ type Cache interface {
 	ZRemove(key string, value interface{}) error
 	GetString(key string) (string, error)
 	GetStringSorted(key, min, max string) []string
+	GetStringSortedWithScores(key, min, max string) []response.ZSetWithScoreData
 	GetInt(key string) (int, error)
 	GetBool(key string) (bool, error)
 
 	HashSet(key string, hash map[string]string, expiration time.Duration) error
 	HashGet(key string) (map[string]string, error)
+
+	Publish(channel string, payload interface{}) error
+	Subcribe(channel string) *redis.PubSub
 }

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -73,6 +73,10 @@ func (c *redisCache) ZRemove(key string, value interface{}) error {
 	return c.rdb.ZRem(context.Background(), key, value).Err()
 }
 
+func (c *redisCache) ZRemoveByScore(key, min, max string) error {
+	return c.rdb.ZRemRangeByScore(context.Background(), key, min, max).Err()
+}
+
 func (c *redisCache) GetString(key string) (string, error) {
 	res, err := c.rdb.Get(context.Background(), key).Result()
 	switch err {

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -2,9 +2,12 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-redis/redis/v8"
+
+	"github.com/defipod/mochi/pkg/response"
 )
 
 type redisCache struct {
@@ -89,6 +92,21 @@ func (c *redisCache) GetStringSorted(key, min, max string) []string {
 	}).Val()
 }
 
+func (c *redisCache) GetStringSortedWithScores(key, min, max string) []response.ZSetWithScoreData {
+	results := c.rdb.ZRangeByScoreWithScores(context.Background(), key, &redis.ZRangeBy{
+		Min: min,
+		Max: max,
+	}).Val()
+	parsedResults := make([]response.ZSetWithScoreData, 0, len(results))
+	for _, v := range results {
+		value := response.ZSetWithScoreData{}
+		value.Member = fmt.Sprintf("%v", v.Member)
+		value.Score = v.Score
+		parsedResults = append(parsedResults, value)
+	}
+	return parsedResults
+}
+
 func (c *redisCache) GetInt(key string) (int, error) {
 	res, err := c.rdb.Get(context.Background(), key).Int()
 	switch err {
@@ -127,4 +145,17 @@ func (c *redisCache) HashGet(key string) (map[string]string, error) {
 	default:
 		return nil, err
 	}
+}
+
+func (c *redisCache) Publish(channel string, payload interface{}) error {
+	err := c.rdb.Publish(context.Background(), channel, payload).Err()
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}
+
+func (c *redisCache) Subcribe(channel string) *redis.PubSub {
+	subcriber := c.rdb.Subscribe(context.Background(), channel)
+	return subcriber
 }

--- a/pkg/entities/cache.go
+++ b/pkg/entities/cache.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-redis/redis/v8"
+
 	"github.com/defipod/mochi/pkg/logger"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/response"
@@ -65,4 +67,20 @@ func (e *Entity) GetTokenAlertZCache(symbol, trend, min, max string) []string {
 
 func (e *Entity) DeleteTokenAlertZCache(symbol, trend, value string) error {
 	return e.cache.ZRemove(fmt.Sprintf("alert_%s_%s", symbol, trend), value)
+}
+
+func (e *Entity) GetPriceAlertZCache(symbol, trend, min, max string) []response.ZSetWithScoreData {
+	return e.cache.GetStringSortedWithScores(fmt.Sprintf("alert_direction_%s:%s", trend, symbol), min, max)
+}
+
+func (e *Entity) RemovePriceAlertZCache(symbol, trend, value string) error {
+	return e.cache.ZRemove(fmt.Sprintf("alert_direction_%s:%s", trend, symbol), value)
+}
+
+func (e *Entity) Publish(channel string, payload interface{}) error {
+	return e.cache.Publish(channel, payload)
+}
+
+func (e *Entity) Subcribe(channel string) *redis.PubSub {
+	return e.cache.Subcribe(channel)
 }

--- a/pkg/entities/cache.go
+++ b/pkg/entities/cache.go
@@ -73,8 +73,12 @@ func (e *Entity) GetPriceAlertZCache(symbol, trend, min, max string) []response.
 	return e.cache.GetStringSortedWithScores(fmt.Sprintf("alert_direction_%s:%s", trend, symbol), min, max)
 }
 
-func (e *Entity) RemovePriceAlertZCache(symbol, trend, value string) error {
-	return e.cache.ZRemove(fmt.Sprintf("alert_direction_%s:%s", trend, symbol), value)
+func (e *Entity) RemovePriceAlertZCache(symbol, trend, price string) error {
+	if trend == "up" {
+		return e.cache.ZRemoveByScore(fmt.Sprintf("alert_direction_%s:%s", trend, symbol), "0", price)
+	} else {
+		return e.cache.ZRemoveByScore(fmt.Sprintf("alert_direction_%s:%s", trend, symbol), price, "inf")
+	}
 }
 
 func (e *Entity) Publish(channel string, payload interface{}) error {

--- a/pkg/job/watch_coin_price_change.go
+++ b/pkg/job/watch_coin_price_change.go
@@ -114,13 +114,13 @@ func (job *watchCoinPriceChanges) Run() error {
 			payload.Direction = direction
 			payload.Symbol = data.Symbol
 			payload.UserID = v.Member
-			cooldownKey := v.Member + ":" + data.Symbol
+			cooldownKey := fmt.Sprintf("%v:%v:%v", v.Member, data.Symbol, v.Score)
 			if cooldownMap[cooldownKey] {
 				continue
 			} else {
 				cooldownMap[cooldownKey] = true
-				time.AfterFunc(120*time.Second, func() {
-					job.log.Infof("User with ID %v - 2mins cool down end", v.Member)
+				time.AfterFunc(60*time.Second, func() {
+					job.log.Infof("User with ID %v - Symbol %v - Price %v - 60s cool down end", v.Member, data.Symbol, v.Score)
 					cooldownMap[cooldownKey] = false
 				})
 				job.cache.Publish(COMMUNICATION_CHANNEL, payload)

--- a/pkg/job/watch_coin_price_change.go
+++ b/pkg/job/watch_coin_price_change.go
@@ -1,27 +1,131 @@
 package job
 
 import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/gorilla/websocket"
+
+	"github.com/defipod/mochi/pkg/cache"
+	"github.com/defipod/mochi/pkg/config"
 	"github.com/defipod/mochi/pkg/entities"
 	"github.com/defipod/mochi/pkg/logger"
+	"github.com/defipod/mochi/pkg/response"
 )
 
 type watchCoinPriceChanges struct {
 	entity *entities.Entity
 	log    logger.Logger
+	cache  cache.Cache
+}
+
+type watchCoinPriceChangePayload struct {
+	UserID    string  `json:"user_id"`
+	Price     float64 `json:"price"`
+	Symbol    string  `json:"symbol"`
+	Direction string  `json:"direction"`
+}
+
+func (m *watchCoinPriceChangePayload) UnmarshalBinary(data []byte) error {
+	// convert data to yours, let's assume its json data
+	return json.Unmarshal(data, m)
+}
+
+func (m watchCoinPriceChangePayload) MarshalBinary() ([]byte, error) {
+	return json.Marshal(m)
 }
 
 func NewWatchCoinPriceChange(e *entities.Entity, l logger.Logger) Job {
+	cfg := config.LoadConfig(config.DefaultConfigLoaders())
+	redisOpt, err := redis.ParseURL(cfg.RedisURL)
+	if err != nil {
+		log.Fatal(err, "[WatchCoinPriceChanges] failed to init redis")
+	}
+
+	cache, err := cache.NewRedisCache(redisOpt)
+	if err != nil {
+		log.Fatal(err, "[WatchCoinPriceChanges] failed to init redis cache")
+	}
 	return &watchCoinPriceChanges{
 		entity: e,
 		log:    l,
+		cache:  cache,
 	}
 }
 
-// TODO: implement this job later
 func (job *watchCoinPriceChanges) Run() error {
-	l := job.log
-	// cfg := config.LoadConfig(config.DefaultConfigLoaders())
+	var COMMUNICATION_CHANNEL = "channel_dm_price_alert"
 
-	l.Infof("watchCoinPriceChanges finished")
+	alertSymbols, err := job.entity.GetListAlertSymbols()
+	if err != nil {
+		job.log.Error(err, "failed to fetch list alert tokens")
+		return err
+	}
+	paramStr := ""
+	for _, v := range alertSymbols {
+		paramStr += "/" + strings.ToLower(v) + "usdt@kline_1s"
+	}
+
+	conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("wss://stream.binance.com:9443/ws%s", paramStr), nil)
+	defer conn.Close()
+	if err != nil {
+		job.log.Error(err, "failed to connect to websocket")
+		return err
+	}
+
+	// binance will send ping message
+	conn.SetPingHandler(func(appData string) error {
+		job.log.Info("ping frame responded")
+		return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(5*time.Second))
+	})
+
+	cooldownMap := make(map[string]bool)
+	for {
+		_, message, _ := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		var data response.WebsocketKlinesDataResponse
+		json.Unmarshal(message, &data)
+		if !strings.Contains(data.Symbol, "USDT") {
+			continue
+		}
+		alertCache := []response.ZSetWithScoreData{}
+		openPrice, _ := strconv.ParseFloat(data.Data.OPrice, 64)
+		closePrice, _ := strconv.ParseFloat(data.Data.CPrice, 64)
+		tokenSymbol := data.Symbol[0 : len(data.Symbol)-4] //format: <symbol>USDT
+		direction := "up"
+		if openPrice-closePrice < 0 {
+			alertCache = job.entity.GetPriceAlertZCache(strings.ToLower(data.Symbol), direction, "0", data.Data.CPrice)
+		} else {
+			direction = "down"
+			alertCache = job.entity.GetPriceAlertZCache(strings.ToLower(data.Symbol), direction, data.Data.CPrice, "inf")
+		}
+		job.log.Infof("Got data from %s - price %v :", tokenSymbol, data.Data.CPrice, alertCache)
+
+		for _, v := range alertCache {
+			payload := watchCoinPriceChangePayload{}
+			payload.Price = v.Score
+			payload.Direction = direction
+			payload.Symbol = data.Symbol
+			payload.UserID = v.Member
+			cooldownKey := v.Member + ":" + data.Symbol
+			if cooldownMap[cooldownKey] {
+				continue
+			} else {
+				cooldownMap[cooldownKey] = true
+				time.AfterFunc(120*time.Second, func() {
+					job.log.Infof("User with ID %v - 2mins cool down end", v.Member)
+					cooldownMap[cooldownKey] = false
+				})
+				job.cache.Publish(COMMUNICATION_CHANNEL, payload)
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/job/watch_coin_price_change.go
+++ b/pkg/job/watch_coin_price_change.go
@@ -73,7 +73,8 @@ func (job *watchCoinPriceChanges) Run() error {
 	// }
 	// conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("wss://stream.binance.com:9443/ws%s", paramStr), nil)
 
-	conn, _, err := websocket.DefaultDialer.Dial("wss://stream.binance.com:9443/ws/bnbusdt@kline_1s/btcusdt@kline_1s/solusdt@kline_1s/ftmusdt@kline_1s/magicusdt@kline_1s", nil)
+	paramStr := "/bnbusdt@kline_1s/btcusdt@kline_1s/solusdt@kline_1s/ftmusdt@kline_1s/magicusdt@kline_1s/ethusdt@kline_1s/xrpusdt@kline_1s/filusdt@kline_1s"
+	conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("wss://stream.binance.com:9443/ws%s", paramStr), nil)
 	defer conn.Close()
 	if err != nil {
 		job.log.Error(err, "failed to connect to websocket")

--- a/pkg/job/watch_coin_price_change.go
+++ b/pkg/job/watch_coin_price_change.go
@@ -61,17 +61,19 @@ func NewWatchCoinPriceChange(e *entities.Entity, l logger.Logger) Job {
 func (job *watchCoinPriceChanges) Run() error {
 	var COMMUNICATION_CHANNEL = "channel_dm_price_alert"
 
-	alertSymbols, err := job.entity.GetListAlertSymbols()
-	if err != nil {
-		job.log.Error(err, "failed to fetch list alert tokens")
-		return err
-	}
-	paramStr := ""
-	for _, v := range alertSymbols {
-		paramStr += "/" + strings.ToLower(v) + "usdt@kline_1s"
-	}
+	// TODO: Refactor to dynamically fetch list of symbols from database
+	// alertSymbols, err := job.entity.GetListAlertSymbols()
+	// if err != nil {
+	// 	job.log.Error(err, "failed to fetch list alert tokens")
+	// 	return err
+	// }
+	// paramStr := ""
+	// for _, v := range alertSymbols {
+	// 	paramStr += "/" + strings.ToLower(v) + "usdt@kline_1s"
+	// }
+	// conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("wss://stream.binance.com:9443/ws%s", paramStr), nil)
 
-	conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("wss://stream.binance.com:9443/ws%s", paramStr), nil)
+	conn, _, err := websocket.DefaultDialer.Dial("wss://stream.binance.com:9443/ws/bnbusdt@kline_1s/btcusdt@kline_1s/solusdt@kline_1s/ftmusdt@kline_1s/magicusdt@kline_1s", nil)
 	defer conn.Close()
 	if err != nil {
 		job.log.Error(err, "failed to connect to websocket")
@@ -106,9 +108,9 @@ func (job *watchCoinPriceChanges) Run() error {
 			direction = "down"
 			alertCache = job.entity.GetPriceAlertZCache(strings.ToLower(data.Symbol), direction, data.Data.CPrice, "inf")
 		}
-		job.log.Infof("Got data from %s - price %v :", tokenSymbol, data.Data.CPrice, alertCache)
 
 		for _, v := range alertCache {
+			job.log.Infof("Received %s - price %v :", tokenSymbol, data.Data.CPrice, alertCache)
 			payload := watchCoinPriceChangePayload{}
 			payload.Price = v.Score
 			payload.Direction = direction

--- a/pkg/job/watch_coin_price_change.go
+++ b/pkg/job/watch_coin_price_change.go
@@ -75,11 +75,11 @@ func (job *watchCoinPriceChanges) Run() error {
 
 	paramStr := "/bnbusdt@kline_1s/btcusdt@kline_1s/solusdt@kline_1s/ftmusdt@kline_1s/magicusdt@kline_1s/ethusdt@kline_1s/xrpusdt@kline_1s/filusdt@kline_1s"
 	conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("wss://stream.binance.com:9443/ws%s", paramStr), nil)
-	defer conn.Close()
 	if err != nil {
 		job.log.Error(err, "failed to connect to websocket")
 		return err
 	}
+	defer conn.Close()
 
 	// binance will send ping message
 	conn.SetPingHandler(func(appData string) error {
@@ -98,7 +98,7 @@ func (job *watchCoinPriceChanges) Run() error {
 		if !strings.Contains(data.Symbol, "USDT") {
 			continue
 		}
-		alertCache := []response.ZSetWithScoreData{}
+		var alertCache []response.ZSetWithScoreData
 		openPrice, _ := strconv.ParseFloat(data.Data.OPrice, 64)
 		closePrice, _ := strconv.ParseFloat(data.Data.CPrice, 64)
 		tokenSymbol := data.Symbol[0 : len(data.Symbol)-4] //format: <symbol>USDT

--- a/pkg/job/watch_dm_notify_price_alert.go
+++ b/pkg/job/watch_dm_notify_price_alert.go
@@ -71,12 +71,11 @@ func (job *watchDMNotifyPriceAlert) Run() error {
 
 func (job *watchDMNotifyPriceAlert) HandleNotifyDiscordUser(payload watchCoinPriceChangePayload) error {
 	req := request.RemoveTokenPriceAlertRequest{}
-	req.Price = payload.Price
+	req.Value = payload.Price
 	req.Symbol = payload.Symbol[0 : len(payload.Symbol)-4]
 	req.UserDiscordID = payload.UserID
 	alert, err := job.entity.GetSpecificAlert(req)
 	if err != nil {
-		job.log.Fields(logger.Fields{"req": req}).Error(err, "[job.HandleNotifyDiscordUser] entity.GetSpecificAlert() failed")
 		return err
 	}
 
@@ -86,8 +85,8 @@ func (job *watchDMNotifyPriceAlert) HandleNotifyDiscordUser(payload watchCoinPri
 		return nil
 	}
 
-	// TODO: Specify DM Message based on Alert Type
-	err = job.svc.Discord.SendDMUserPriceAlert(alert.UserDiscordID)
+	tradingPair := alert.Symbol + "/" + alert.Currency
+	err = job.svc.Discord.SendDMUserPriceAlert(alert.UserDiscordID, tradingPair, alert.AlertType, alert.Value)
 	if err != nil {
 		job.log.Fields(logger.Fields{"user_discord_id": alert.UserDiscordID}).Error(err, "[job.HandleNotifyDiscordUser] svc.Discord.SendDMUserPriceAlert() failed")
 		return err

--- a/pkg/job/watch_dm_notify_price_alert.go
+++ b/pkg/job/watch_dm_notify_price_alert.go
@@ -1,0 +1,111 @@
+package job
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+
+	"github.com/defipod/mochi/pkg/cache"
+	"github.com/defipod/mochi/pkg/config"
+	"github.com/defipod/mochi/pkg/entities"
+	"github.com/defipod/mochi/pkg/logger"
+	"github.com/defipod/mochi/pkg/model"
+	"github.com/defipod/mochi/pkg/request"
+	"github.com/defipod/mochi/pkg/service"
+	"github.com/defipod/mochi/pkg/util"
+)
+
+type watchDMNotifyPriceAlert struct {
+	entity *entities.Entity
+	log    logger.Logger
+	cache  cache.Cache
+	svc    *service.Service
+}
+
+func NewWatchDMNotifyPriceAlert(e *entities.Entity, l logger.Logger) Job {
+	cfg := config.LoadConfig(config.DefaultConfigLoaders())
+
+	// init redis
+	redisOpt, err := redis.ParseURL(cfg.RedisURL)
+	if err != nil {
+		l.Fatal(err, "[WatchDMNotifyPriceAlert] failed to init redis")
+	}
+
+	cache, err := cache.NewRedisCache(redisOpt)
+	if err != nil {
+		l.Fatal(err, "[WatchDMNotifyPriceAlert] failed to init redis cache")
+	}
+
+	service, err := service.NewService(cfg, l)
+	if err != nil {
+		l.Fatal(err, "failed to init service")
+	}
+
+	return &watchDMNotifyPriceAlert{
+		entity: e,
+		log:    l,
+		svc:    service,
+		cache:  cache,
+	}
+}
+
+func (job *watchDMNotifyPriceAlert) Run() error {
+	var COMMUNICATION_CHANNEL = "channel_dm_price_alert"
+	subcriber := job.cache.Subcribe(COMMUNICATION_CHANNEL)
+	defer subcriber.Close()
+
+	ch := subcriber.Channel()
+
+	for msg := range ch {
+		var data watchCoinPriceChangePayload
+		if err := json.Unmarshal([]byte(msg.Payload), &data); err != nil {
+			panic(err)
+		}
+		job.log.Infof("Received %v", data)
+		job.HandleNotifyDiscordUser(data)
+	}
+
+	return nil
+}
+
+func (job *watchDMNotifyPriceAlert) HandleNotifyDiscordUser(payload watchCoinPriceChangePayload) error {
+	req := request.RemoveTokenPriceAlertRequest{}
+	req.Price = payload.Price
+	req.Symbol = payload.Symbol[0 : len(payload.Symbol)-4]
+	req.UserDiscordID = payload.UserID
+	alert, err := job.entity.GetSpecificAlert(req)
+	if err != nil {
+		job.log.Fields(logger.Fields{"req": req}).Error(err, "[job.HandleNotifyDiscordUser] entity.GetSpecificAlert() failed")
+		return err
+	}
+
+	nowTime := time.Now().UTC()
+	if nowTime.Before(alert.SnoozedTo) {
+		job.log.Infof("User ID %v - Symbol %v - Next available to DM date is after %v", alert.UserDiscordID, alert.Symbol, alert.SnoozedTo)
+		return nil
+	}
+
+	// TODO: Specify DM Message based on Alert Type
+	err = job.svc.Discord.SendDMUserPriceAlert(alert.UserDiscordID)
+	if err != nil {
+		job.log.Fields(logger.Fields{"user_discord_id": alert.UserDiscordID}).Error(err, "[job.HandleNotifyDiscordUser] svc.Discord.SendDMUserPriceAlert() failed")
+		return err
+	}
+
+	if alert.Frequency == model.OnlyOnce {
+		err = job.entity.RemoveTokenPriceAlert(req)
+		if err != nil {
+			job.log.Fields(logger.Fields{"req": req}).Error(err, "[job.HandleNotifyDiscordUser] entity.RemoveTokenPriceAlert() failed")
+			return err
+		}
+		return nil
+	}
+	if alert.Frequency == model.OnceADay {
+		alert.SnoozedTo = util.StartOfDay(time.Now().AddDate(0, 0, 1)) // update to the start of next day
+		err = job.entity.UpdateSpecificPriceAlert(*alert)
+		return nil
+	}
+
+	return nil
+}

--- a/pkg/model/errors/validator.go
+++ b/pkg/model/errors/validator.go
@@ -18,6 +18,7 @@ var (
 	ErrInvalidVoteChoice         = NewStringError("Invalid vote choice", 400)
 	ErrInvalidAuthorityType      = NewStringError("Invalid authority type", 400)
 	ErrInvalidAlertType          = NewStringError("Invalid alert type - Must be in (price_reaches, price_rises_above, price_drops_to, change_is_over, change_is_under)", 400)
+	ErrInvalidAlertValue         = NewStringError("Invalid alert value - Must greater than 0.01 for percentage or 0 for price", 400)
 	ErrInvalidAlertFrequencyType = NewStringError("Invalid alert frequency type - Must be in (only_once, once_a_day, always)", 400)
 	ErrTokenNotFound             = NewStringError("Token not found", 404)
 	ErrXPRoleExisted             = NewStringError("XP role config already existed", 400)

--- a/pkg/model/user_token_price_alert.go
+++ b/pkg/model/user_token_price_alert.go
@@ -25,15 +25,16 @@ const (
 )
 
 type UserTokenPriceAlert struct {
-	UserDiscordID string         `json:"user_discord_id"`
-	Symbol        string         `json:"symbol"`
-	Currency      string         `json:"currency"`
-	AlertType     AlertType      `json:"alert_type"`
-	Frequency     AlertFrequency `json:"frequency"`
-	Price         float64        `json:"price"`
-	SnoozedTo     time.Time      `json:"snoozed_to"`
-	CreatedAt     time.Time      `json:"created_at"`
-	UpdatedAt     time.Time      `json:"updated_at"`
+	UserDiscordID  string         `json:"user_discord_id"`
+	Symbol         string         `json:"symbol"`
+	Currency       string         `json:"currency"`
+	AlertType      AlertType      `json:"alert_type"`
+	Frequency      AlertFrequency `json:"frequency"`
+	Value          float64        `json:"value"`
+	PriceByPercent float64        `json:"price_by_percent"`
+	SnoozedTo      time.Time      `json:"snoozed_to"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
 }
 
 func (c AlertFrequency) IsValidAlertFrequency() error {

--- a/pkg/model/user_token_price_alert.go
+++ b/pkg/model/user_token_price_alert.go
@@ -52,6 +52,17 @@ func (c AlertType) IsValidAlertType() error {
 	return errors.ErrInvalidAlertType
 }
 
+func (c AlertType) GetRedisKeyPrefix() string {
+	switch c {
+	case PriceDropsTo, ChangeIsUnder:
+		return "alert_direction_down"
+	case PriceReaches, PriceRisesAbove, ChangeIsOver:
+		return "alert_direction_up"
+	default:
+		return ""
+	}
+}
+
 func (UserTokenPriceAlert) TableName() string {
 	return "user_token_price_alerts"
 }

--- a/pkg/repo/user_token_price_alert/pg.go
+++ b/pkg/repo/user_token_price_alert/pg.go
@@ -18,6 +18,12 @@ func (pg *pg) Create(item *model.UserTokenPriceAlert) error {
 	return pg.db.Create(item).Error
 }
 
+func (pg *pg) GetOne(q UserTokenPriceAlertQuery) (model.UserTokenPriceAlert, error) {
+	var item model.UserTokenPriceAlert
+	db := pg.db.Table("user_token_price_alerts")
+	return item, db.Where("user_discord_id = ? AND symbol = ? AND price = ?", q.UserDiscordID, q.Symbol, q.Price).First(&item).Error
+}
+
 func (pg *pg) List(q UserTokenPriceAlertQuery) ([]model.UserTokenPriceAlert, int64, error) {
 	var items []model.UserTokenPriceAlert
 	var total int64
@@ -45,4 +51,9 @@ func (pg *pg) Delete(userID, symbol string, price float64) (int64, error) {
 
 func (pg *pg) Update(item *model.UserTokenPriceAlert) error {
 	return pg.db.Where("user_discord_id = ? AND symbol = ?", item.UserDiscordID, item.Symbol).Save(item).Error
+}
+
+func (pg *pg) FetchListSymbol() ([]string, error) {
+	var symbols []string
+	return symbols, pg.db.Table("user_token_price_alerts").Distinct().Pluck("symbol", &symbols).Error
 }

--- a/pkg/repo/user_token_price_alert/pg.go
+++ b/pkg/repo/user_token_price_alert/pg.go
@@ -49,19 +49,13 @@ func (pg *pg) List(q UserTokenPriceAlertQuery) ([]model.UserTokenPriceAlert, int
 	return items, total, db.Find(&items).Error
 }
 
-func (pg *pg) Delete(userID, symbol string, value, priceByPercent float64) (int64, error) {
-	db := pg.db.Table("user_token_price_alerts")
-	if priceByPercent != 0 {
-		db = db.Where("price_by_percent = ?", priceByPercent)
-	} else {
-		db = db.Where("value = ?", value)
-	}
-	tx := pg.db.Where("user_discord_id = ? AND symbol ILIKE ?", userID, symbol).Delete(&model.UserTokenPriceAlert{})
+func (pg *pg) Delete(userID, symbol string, value float64) (int64, error) {
+	tx := pg.db.Delete(&model.UserTokenPriceAlert{}, "user_discord_id = ? AND symbol ILIKE ? AND value = ?", userID, symbol, value)
 	return tx.RowsAffected, tx.Error
 }
 
 func (pg *pg) Update(item *model.UserTokenPriceAlert) error {
-	return pg.db.Where("user_discord_id = ? AND symbol = ?", item.UserDiscordID, item.Symbol).Save(item).Error
+	return pg.db.Where("user_discord_id = ? AND symbol = ? AND value = ? AND price_by_percent = ? ", item.UserDiscordID, item.Symbol, item.Value, item.PriceByPercent).Save(item).Error
 }
 
 func (pg *pg) FetchListSymbol() ([]string, error) {

--- a/pkg/repo/user_token_price_alert/store.go
+++ b/pkg/repo/user_token_price_alert/store.go
@@ -12,7 +12,9 @@ type UserTokenPriceAlertQuery struct {
 
 type Store interface {
 	List(q UserTokenPriceAlertQuery) (items []model.UserTokenPriceAlert, total int64, err error)
+	GetOne(q UserTokenPriceAlertQuery) (item model.UserTokenPriceAlert, err error)
 	Create(item *model.UserTokenPriceAlert) error
 	Delete(userID, symbol string, price float64) (rows int64, err error)
 	Update(item *model.UserTokenPriceAlert) error
+	FetchListSymbol() ([]string, error)
 }

--- a/pkg/repo/user_token_price_alert/store.go
+++ b/pkg/repo/user_token_price_alert/store.go
@@ -15,7 +15,7 @@ type Store interface {
 	List(q UserTokenPriceAlertQuery) (items []model.UserTokenPriceAlert, total int64, err error)
 	GetOne(q UserTokenPriceAlertQuery) (item model.UserTokenPriceAlert, err error)
 	Create(item *model.UserTokenPriceAlert) error
-	Delete(userID, symbol string, value, priceByPercent float64) (rows int64, err error)
+	Delete(userID, symbol string, value float64) (rows int64, err error)
 	Update(item *model.UserTokenPriceAlert) error
 	FetchListSymbol() ([]string, error)
 }

--- a/pkg/repo/user_token_price_alert/store.go
+++ b/pkg/repo/user_token_price_alert/store.go
@@ -3,18 +3,19 @@ package usertokenpricealert
 import "github.com/defipod/mochi/pkg/model"
 
 type UserTokenPriceAlertQuery struct {
-	UserDiscordID string
-	Symbol        string
-	Price         float64
-	Limit         int
-	Offset        int
+	UserDiscordID  string
+	Symbol         string
+	Value          float64
+	PriceByPercent float64
+	Limit          int
+	Offset         int
 }
 
 type Store interface {
 	List(q UserTokenPriceAlertQuery) (items []model.UserTokenPriceAlert, total int64, err error)
 	GetOne(q UserTokenPriceAlertQuery) (item model.UserTokenPriceAlert, err error)
 	Create(item *model.UserTokenPriceAlert) error
-	Delete(userID, symbol string, price float64) (rows int64, err error)
+	Delete(userID, symbol string, value, priceByPercent float64) (rows int64, err error)
 	Update(item *model.UserTokenPriceAlert) error
 	FetchListSymbol() ([]string, error)
 }

--- a/pkg/request/defi.go
+++ b/pkg/request/defi.go
@@ -59,11 +59,12 @@ type GetFiatHistoricalExchangeRatesRequest struct {
 }
 
 type AddTokenPriceAlertRequest struct {
-	UserDiscordID string               `json:"user_discord_id"`
-	Symbol        string               `json:"symbol"`
-	AlertType     model.AlertType      `json:"alert_type" enums:"price_reaches,price_rises_above,price_drops_to,change_is_over,change_is_under"`
-	Frequency     model.AlertFrequency `json:"frequency" enums:"only_once,once_a_day,always"`
-	Price         float64              `json:"price"`
+	UserDiscordID  string               `json:"user_discord_id"`
+	Symbol         string               `json:"symbol"`
+	AlertType      model.AlertType      `json:"alert_type" enums:"price_reaches,price_rises_above,price_drops_to,change_is_over,change_is_under"`
+	Frequency      model.AlertFrequency `json:"frequency" enums:"only_once,once_a_day,always"`
+	Value          float64              `json:"value"`
+	PriceByPercent float64              `json:"price_by_percent"`
 }
 
 type GetUserListPriceAlertRequest struct {
@@ -73,7 +74,8 @@ type GetUserListPriceAlertRequest struct {
 }
 
 type RemoveTokenPriceAlertRequest struct {
-	UserDiscordID string  `json:"user_discord_id" form:"user_discord_id" binding:"required"`
-	Symbol        string  `json:"symbol" form:"symbol" binding:"required"`
-	Price         float64 `json:"price" form:"price" binding:"required"`
+	UserDiscordID  string  `json:"user_discord_id" form:"user_discord_id" binding:"required"`
+	Symbol         string  `json:"symbol" form:"symbol" binding:"required"`
+	Value          float64 `json:"value" form:"value" binding:"required"`
+	PriceByPercent float64 `json:"price_by_percent" form:"price_by_percent"`
 }

--- a/pkg/request/defi.go
+++ b/pkg/request/defi.go
@@ -78,4 +78,5 @@ type RemoveTokenPriceAlertRequest struct {
 	Symbol         string  `json:"symbol" form:"symbol" binding:"required"`
 	Value          float64 `json:"value" form:"value" binding:"required"`
 	PriceByPercent float64 `json:"price_by_percent" form:"price_by_percent"`
+	PriceDirection string  `json:"price_direction" form:"price_direction"`
 }

--- a/pkg/response/binance.go
+++ b/pkg/response/binance.go
@@ -38,3 +38,13 @@ type WebsocketKlinesData struct {
 	QuoteAssetVolume string `json:"q"`
 	NumOfTrades      int64  `json:"n"`
 }
+
+type WebsocketAggTradeDataResponse struct {
+	Symbol string `json:"s"`
+	Price  string `json:"p"`
+}
+
+type GetAvgPriceBySymbolResponse struct {
+	Mins  int64  `json:"mins"`
+	Price string `json:"price"`
+}

--- a/pkg/response/cache.go
+++ b/pkg/response/cache.go
@@ -6,3 +6,8 @@ type SetUpvoteMessageCacheResponse struct {
 	ChannelID string `json:"channel_id"`
 	MessageID string `json:"message_id"`
 }
+
+type ZSetWithScoreData struct {
+	Score  float64 `json:"score"`
+	Member string  `json:"member"`
+}

--- a/pkg/response/defi.go
+++ b/pkg/response/defi.go
@@ -201,13 +201,14 @@ type GetFiatHistoricalExchangeRatesResponse struct {
 }
 
 type TokenPriceAlertResponseData struct {
-	UserDiscordID string    `json:"user_discord_id"`
-	Symbol        string    `json:"symbol"`
-	Currency      string    `json:"currency"`
-	AlertType     string    `json:"alert_type"`
-	Frequency     string    `json:"frequency"`
-	Price         float64   `json:"price"`
-	SnoozedTo     time.Time `json:"snoozed_to"`
+	UserDiscordID  string    `json:"user_discord_id"`
+	Symbol         string    `json:"symbol"`
+	Currency       string    `json:"currency"`
+	AlertType      string    `json:"alert_type"`
+	Frequency      string    `json:"frequency"`
+	Value          float64   `json:"value"`
+	PriceByPercent float64   `json:"price_by_percent"`
+	SnoozedTo      time.Time `json:"snoozed_to"`
 }
 
 type AddTokenPriceAlertResponse struct {

--- a/pkg/service/binance/binance.go
+++ b/pkg/service/binance/binance.go
@@ -12,12 +12,14 @@ import (
 type Binance struct {
 	getExchangeInfoURL string
 	getSymbolKlinesURL string
+	getAvgPriceURL     string
 }
 
 func NewService() Service {
 	return &Binance{
 		getExchangeInfoURL: "https://api.binance.com/api/v3/exchangeInfo",
 		getSymbolKlinesURL: "https://api.binance.com/api/v3/uiKlines?symbol=%s&interval=1h&limit=168", // 168h = 7d
+		getAvgPriceURL:     "https://api.binance.com/api/v3/avgPrice",
 	}
 }
 
@@ -31,6 +33,20 @@ func (b *Binance) GetExchangeInfo(symbol string) (*response.GetExchangeInfoRespo
 	statusCode, err := util.FetchData(url, res)
 	if err != nil || statusCode != http.StatusOK {
 		return nil, fmt.Errorf("binance.GetExchangeInfo() failed: %v", err), statusCode
+	}
+	return res, nil, http.StatusOK
+}
+
+func (b *Binance) GetAvgPriceBySymbol(symbol string) (*response.GetAvgPriceBySymbolResponse, error, int) {
+	symbol = strings.Replace(symbol, "/", "", 1)
+	res := &response.GetAvgPriceBySymbolResponse{}
+	url := b.getAvgPriceURL
+	if symbol != "" {
+		url = fmt.Sprintf("%s?symbol=%s", url, symbol)
+	}
+	statusCode, err := util.FetchData(url, res)
+	if err != nil || statusCode != http.StatusOK {
+		return nil, fmt.Errorf("binance.GetAvgPriceBySymbol() failed: %v", err), statusCode
 	}
 	return res, nil, http.StatusOK
 }

--- a/pkg/service/binance/service.go
+++ b/pkg/service/binance/service.go
@@ -7,4 +7,5 @@ import (
 type Service interface {
 	GetExchangeInfo(symbol string) (*response.GetExchangeInfoResponse, error, int)
 	GetKlinesBySymbol(symbol string) ([]response.GetKlinesDataResponse, error, int)
+	GetAvgPriceBySymbol(symbol string) (*response.GetAvgPriceBySymbolResponse, error, int)
 }

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -693,3 +693,22 @@ func (d *Discord) NotifyNewCommonwealthDiscussion(channelID string, discussion r
 	}
 	return err
 }
+
+func (d *Discord) SendDMUserPriceAlert(userID string) error {
+	privChan, err := d.session.UserChannelCreate(userID)
+	if err != nil {
+		d.log.Error(err, "[discord.SendDMUserPriceAlert] d.session.UserChannelCreate() failed")
+		return err
+	}
+	msg := &discordgo.MessageSend{
+		Embed: &discordgo.MessageEmbed{
+			Title: "Price Alert Triggered",
+			// Footer:      &discordgo.MessageEmbedFooter{Text: req.Username, IconURL: req.Avatar},
+			Description: fmt.Sprintf("Hi, your price alert has been triggered !"),
+			Color:       mochiLogColor,
+			Timestamp:   time.Now().Format("2006-01-02T15:04:05Z07:00"),
+		},
+	}
+	d.session.ChannelMessageSendComplex(privChan.ID, msg)
+	return nil
+}

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -694,7 +694,20 @@ func (d *Discord) NotifyNewCommonwealthDiscussion(channelID string, discussion r
 	return err
 }
 
-func (d *Discord) SendDMUserPriceAlert(userID string) error {
+func (d *Discord) SendDMUserPriceAlert(userID, symbol string, alertType model.AlertType, price float64) error {
+	var description string
+	switch alertType {
+	case model.PriceReaches:
+		description = fmt.Sprintf("%v reaches %v", symbol, price)
+	case model.PriceDropsTo:
+		description = fmt.Sprintf("%v is under %v", symbol, price)
+	case model.PriceRisesAbove:
+		description = fmt.Sprintf("%v rises above %v", symbol, price)
+	case model.ChangeIsOver:
+		description = fmt.Sprintf("%v is up by %v%%", symbol, price)
+	case model.ChangeIsUnder:
+		description = fmt.Sprintf("%v is down by %v%%", symbol, price)
+	}
 	privChan, err := d.session.UserChannelCreate(userID)
 	if err != nil {
 		d.log.Error(err, "[discord.SendDMUserPriceAlert] d.session.UserChannelCreate() failed")
@@ -702,9 +715,8 @@ func (d *Discord) SendDMUserPriceAlert(userID string) error {
 	}
 	msg := &discordgo.MessageSend{
 		Embed: &discordgo.MessageEmbed{
-			Title: "Price Alert Triggered",
-			// Footer:      &discordgo.MessageEmbedFooter{Text: req.Username, IconURL: req.Avatar},
-			Description: fmt.Sprintf("Hi, your price alert has been triggered !"),
+			Title:       "Your price alert is triggered",
+			Description: description,
 			Color:       mochiLogColor,
 			Timestamp:   time.Now().Format("2006-01-02T15:04:05Z07:00"),
 		},

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -278,6 +278,20 @@ func (mr *MockServiceMockRecorder) ReplyUpvoteMessage(msg, source interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplyUpvoteMessage", reflect.TypeOf((*MockService)(nil).ReplyUpvoteMessage), msg, source)
 }
 
+// SendDMUserPriceAlert mocks base method.
+func (m *MockService) SendDMUserPriceAlert(userID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendDMUserPriceAlert", userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendDMUserPriceAlert indicates an expected call of SendDMUserPriceAlert.
+func (mr *MockServiceMockRecorder) SendDMUserPriceAlert(userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDMUserPriceAlert", reflect.TypeOf((*MockService)(nil).SendDMUserPriceAlert), userID)
+}
+
 // SendFeedback mocks base method.
 func (m *MockService) SendFeedback(req *request.UserFeedbackRequest, feedbackID string) error {
 	m.ctrl.T.Helper()

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -279,17 +279,17 @@ func (mr *MockServiceMockRecorder) ReplyUpvoteMessage(msg, source interface{}) *
 }
 
 // SendDMUserPriceAlert mocks base method.
-func (m *MockService) SendDMUserPriceAlert(userID string) error {
+func (m *MockService) SendDMUserPriceAlert(userID, symbol string, alertType model.AlertType, price float64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendDMUserPriceAlert", userID)
+	ret := m.ctrl.Call(m, "SendDMUserPriceAlert", userID, symbol, alertType, price)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendDMUserPriceAlert indicates an expected call of SendDMUserPriceAlert.
-func (mr *MockServiceMockRecorder) SendDMUserPriceAlert(userID interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) SendDMUserPriceAlert(userID, symbol, alertType, price interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDMUserPriceAlert", reflect.TypeOf((*MockService)(nil).SendDMUserPriceAlert), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDMUserPriceAlert", reflect.TypeOf((*MockService)(nil).SendDMUserPriceAlert), userID, symbol, alertType, price)
 }
 
 // SendFeedback mocks base method.

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -42,5 +42,5 @@ type Service interface {
 	CreateDiscussionChannelForProposal(guildId, proposalChannelID, proposalTitle string) (string, error)
 
 	// Price alert
-	SendDMUserPriceAlert(userID string) error
+	SendDMUserPriceAlert(userID, symbol string, alertType model.AlertType, price float64) error
 }

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -40,4 +40,7 @@ type Service interface {
 	NotifyNewProposal(channelID string, proposal response.SnapshotProposalDataResponse) error
 	NotifyNewCommonwealthDiscussion(channelID string, discussion response.CommonwealthDiscussion) error
 	CreateDiscussionChannelForProposal(guildId, proposalChannelID, proposalTitle string) (string, error)
+
+	// Price alert
+	SendDMUserPriceAlert(userID string) error
 }


### PR DESCRIPTION
**What does this PR do?**

-  [x] Add `watchCoinPriceChanges` worker
-  [x] Add `watchDMNotifyPriceAlert` worker

**How to test**
1. Run `make migrate-up`
2. Open two seperate terminal sessions and run below cmds:
- `go run cmd/watch-dm-notify-price-alert/main.go`
- `go run cmd/watch-coin-price-change/main.go`
3. Add new record by API to see how this two workers operate
- Create new alert 
[POST] http://localhost:8200/api/v1/defi/price-alert
Sample req: `{
    "user_discord_id": "490895538892439553",
    "symbol": "btc",
    "alert_type": "price_drops_to",
    "frequency": "only_once",
    "value": 24050
}`

- Remove an Alert
[DELETE] http://localhost:8200/api/v1/defi/price-alert
Sample req: 
![image](https://user-images.githubusercontent.com/27359472/220814213-c3ca9d7f-59cb-4fd0-9b94-c0136736cfa2.png)


**Notes:**
- Supported symbols are in this list (BTC, ETH, BNB, SOL, FTM, MAGIC). **Logic for this should be finanally updated soon**
- `alert_type` should be in `(price_reaches, price_rises_above, price_drops_to, change_is_over, change_is_under)`
- Alert `frequency` should be in `(only_once, once_a_day, always)`

Thanks for your effort on this PR :kek:
