### PR TITLE
fix: evm despoit job - reduce tx query size

### DIFF
--- a/pkg/job/watch_evm_deposits.go
+++ b/pkg/job/watch_evm_deposits.go
@@ -51,7 +51,7 @@ func (job *watchEvmDeposits) Run() error {
 		}
 		chainID := *contract.Chain.ChainID
 		contractAddr := contract.ContractAddress
-		transactionsRes, err := covalentSvc.GetTransactionsByAddress(chainID, contractAddr, 1000, 3)
+		transactionsRes, err := covalentSvc.GetTransactionsByAddress(chainID, contractAddr, 100, 3)
 		if err != nil {
 			log.Error(err, "[watchEvmDeposits] covalentSvc.GetTransactionsByAddress() failed")
 			continue


### PR DESCRIPTION
**What does this PR do?**
currently we're querying 1000 txns / contract while running job watch-evm-deposits (interval = 5m)
-> 1 txn = 0.1 credit
-> we only have 100k monthly credits, so we will reduce query size from 1000 to 100 to avoid covalent API rate limit
