### PR TITLE
Fix: get guild detail - return guild's icon

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6812,6 +6812,12 @@ const docTemplate = `{
                         "description": "Limit",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Platform",
+                        "name": "platform",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -11919,6 +11925,9 @@ const docTemplate = `{
                 },
                 "global_xp": {
                     "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
                 },
                 "id": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6804,6 +6804,12 @@
                         "description": "Limit",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Platform",
+                        "name": "platform",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -11911,6 +11917,9 @@
                 },
                 "global_xp": {
                     "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
                 },
                 "id": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2972,6 +2972,8 @@ definitions:
         type: array
       global_xp:
         type: boolean
+      icon:
+        type: string
       id:
         type: string
       log_channel:
@@ -8966,6 +8968,10 @@ paths:
         in: query
         name: limit
         type: integer
+      - description: Platform
+        in: query
+        name: platform
+        type: string
       produces:
       - application/json
       responses:

--- a/pkg/entities/guild.go
+++ b/pkg/entities/guild.go
@@ -76,6 +76,11 @@ func (e *Entity) GetGuild(guildID string) (*response.GetGuildResponse, error) {
 		return nil, err
 	}
 
+	discordGuildInfo, err := e.svc.Discord.GetGuild(guildID)
+	if err != nil {
+		return nil, err
+	}
+
 	return &response.GetGuildResponse{
 		ID:           guild.ID,
 		Name:         guild.Name,
@@ -85,6 +90,7 @@ func (e *Entity) GetGuild(guildID string) (*response.GetGuildResponse, error) {
 		LogChannelID: guild.GuildConfigInviteTracker.ChannelID, // TODO: refactor (rename)
 		GlobalXP:     guild.GlobalXP,
 		Active:       true,
+		Icon:         discordGuildInfo.Icon,
 	}, nil
 }
 

--- a/pkg/handler/user/user.go
+++ b/pkg/handler/user/user.go
@@ -199,6 +199,7 @@ func (h *Handler) GetMyInfo(c *gin.Context) {
 // @Param       user_id query     string true "User ID"
 // @Param       page query     int false "Page" default(0)
 // @Param       limit query     int false "Limit" default(10)
+// @Param       platform query     string false "Platform"
 // @Success     200 {object} response.TopUser
 // @Router      /users/top [get]
 func (h *Handler) GetTopUsers(c *gin.Context) {

--- a/pkg/response/guild.go
+++ b/pkg/response/guild.go
@@ -19,6 +19,7 @@ type GetGuildResponse struct {
 	LogChannelID string   `json:"log_channel_id"`
 	GlobalXP     bool     `json:"global_xp"`
 	Active       bool     `json:"active"`
+	Icon         string   `json:"icon"`
 }
 
 type ListAllCustomTokenResponse struct {

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -792,3 +792,16 @@ func (d *Discord) GetGuildMembers(guildID string) ([]*discordgo.Member, error) {
 
 	return result, nil
 }
+
+func (d *Discord) GetGuild(guildID string) (*discordgo.Guild, error) {
+	guild, err := d.session.Guild(guildID)
+	if err != nil {
+		d.log.Error(err, "[discord.GetGuild] d.session.Guild() failed")
+		return nil, err
+	}
+
+	// build guild icon url
+	guild.Icon = discordgo.EndpointGuildIcon(guildID, guild.Icon)
+
+	return guild, nil
+}

--- a/pkg/service/discord/mocks/service.go
+++ b/pkg/service/discord/mocks/service.go
@@ -96,6 +96,21 @@ func (mr *MockServiceMockRecorder) DeleteChannel(channelId interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChannel", reflect.TypeOf((*MockService)(nil).DeleteChannel), channelId)
 }
 
+// GetGuild mocks base method.
+func (m *MockService) GetGuild(guildID string) (*discordgo.Guild, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGuild", guildID)
+	ret0, _ := ret[0].(*discordgo.Guild)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGuild indicates an expected call of GetGuild.
+func (mr *MockServiceMockRecorder) GetGuild(guildID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGuild", reflect.TypeOf((*MockService)(nil).GetGuild), guildID)
+}
+
 // GetGuildMembers mocks base method.
 func (m *MockService) GetGuildMembers(guildID string) ([]*discordgo.Member, error) {
 	m.ctrl.T.Helper()

--- a/pkg/service/discord/service.go
+++ b/pkg/service/discord/service.go
@@ -49,4 +49,5 @@ type Service interface {
 
 	// Guild
 	GetGuildMembers(guildID string) ([]*discordgo.Member, error)
+	GetGuild(guildID string) (*discordgo.Guild, error)
 }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix API `GET /guilds/:guild_id` to return guild's icon url also
-   [x] Update docs

**How to test**

![image](https://user-images.githubusercontent.com/32956772/227867294-b95a6946-e3e6-4efb-8c8a-c072c5b25872.png)
