### PR TITLE
fix: upsert users - update discriminator on conflict

### DIFF
--- a/pkg/repo/users/pg.go
+++ b/pkg/repo/users/pg.go
@@ -35,7 +35,7 @@ func (pg *pg) UpsertMany(users []model.User) error {
 	for _, user := range users {
 		err := tx.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "id"}},
-			DoUpdates: clause.AssignmentColumns([]string{"username"}),
+			DoUpdates: clause.AssignmentColumns([]string{"username", "discriminator"}),
 		}).Create(&user).Error
 		if err != nil {
 			log.Error(err, "[users.UpsertMany] failed")


### PR DESCRIPTION
**What does this PR do?**

-   [x] Whitelist `discriminator` for updating on conflicting when executing upsert many users