### PR TITLE
feat: get list default ticker of a guild

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2521,13 +2521,6 @@ const docTemplate = `{
                         "name": "guild_id",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Guild ticker query",
-                        "name": "query",
-                        "in": "query",
-                        "required": true
                     }
                 ],
                 "responses": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2501,6 +2501,45 @@ const docTemplate = `{
                 }
             }
         },
+        "/config-defi/default-ticker/{guild_id}": {
+            "get": {
+                "description": "Get list default ticker of a guild.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ConfigDefi"
+                ],
+                "summary": "Get list default ticker of a guild.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Guild ID",
+                        "name": "guild_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Guild ticker query",
+                        "name": "query",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.GetListGuildDefaultTickerResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/config-defi/monikers": {
             "post": {
                 "description": "Upsert moniker config",
@@ -8364,6 +8403,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "most_popular": {
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -13230,6 +13272,17 @@ const docTemplate = `{
                 }
             }
         },
+        "response.GetListGuildDefaultTickerResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.GuildConfigDefaultTicker"
+                    }
+                }
+            }
+        },
         "response.GetMyInfoResponse": {
             "type": "object",
             "properties": {
@@ -15457,6 +15510,9 @@ const docTemplate = `{
         "response.SwapRouteResponse": {
             "type": "object",
             "properties": {
+                "chainName": {
+                    "type": "string"
+                },
                 "code": {
                     "type": "integer"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2493,6 +2493,45 @@
                 }
             }
         },
+        "/config-defi/default-ticker/{guild_id}": {
+            "get": {
+                "description": "Get list default ticker of a guild.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ConfigDefi"
+                ],
+                "summary": "Get list default ticker of a guild.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Guild ID",
+                        "name": "guild_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Guild ticker query",
+                        "name": "query",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.GetListGuildDefaultTickerResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/config-defi/monikers": {
             "post": {
                 "description": "Upsert moniker config",
@@ -8356,6 +8395,9 @@
                 "id": {
                     "type": "string"
                 },
+                "most_popular": {
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -13222,6 +13264,17 @@
                 }
             }
         },
+        "response.GetListGuildDefaultTickerResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.GuildConfigDefaultTicker"
+                    }
+                }
+            }
+        },
         "response.GetMyInfoResponse": {
             "type": "object",
             "properties": {
@@ -15449,6 +15502,9 @@
         "response.SwapRouteResponse": {
             "type": "object",
             "properties": {
+                "chainName": {
+                    "type": "string"
+                },
                 "code": {
                     "type": "integer"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2513,13 +2513,6 @@
                         "name": "guild_id",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Guild ticker query",
-                        "name": "query",
-                        "in": "query",
-                        "required": true
                     }
                 ],
                 "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -120,6 +120,8 @@ definitions:
         type: number
       id:
         type: string
+      most_popular:
+        type: boolean
       name:
         type: string
       symbol:
@@ -3302,6 +3304,13 @@ definitions:
           $ref: '#/definitions/model.Chain'
         type: array
     type: object
+  response.GetListGuildDefaultTickerResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/model.GuildConfigDefaultTicker'
+        type: array
+    type: object
   response.GetMyInfoResponse:
     properties:
       data:
@@ -3482,13 +3491,13 @@ definitions:
         type: string
       usd:
         type: number
-      usd_7d_change:
-        type: number
-      usd_14d_change:
-        type: number
       usd_1h_change:
         type: number
       usd_1y_change:
+        type: number
+      usd_7d_change:
+        type: number
+      usd_14d_change:
         type: number
       usd_24h_change:
         type: number
@@ -4251,6 +4260,12 @@ definitions:
         additionalProperties:
           type: number
         type: object
+      price_change_percentage_14d:
+        type: number
+      price_change_percentage_14d_in_currency:
+        additionalProperties:
+          type: number
+        type: object
       price_change_percentage_1h_in_currency:
         additionalProperties:
           type: number
@@ -4264,12 +4279,6 @@ definitions:
       price_change_percentage_7d:
         type: number
       price_change_percentage_7d_in_currency:
-        additionalProperties:
-          type: number
-        type: object
-      price_change_percentage_14d:
-        type: number
-      price_change_percentage_14d_in_currency:
         additionalProperties:
           type: number
         type: object
@@ -4751,6 +4760,8 @@ definitions:
     type: object
   response.SwapRouteResponse:
     properties:
+      chainName:
+        type: string
       code:
         type: integer
       data:
@@ -6580,6 +6591,32 @@ paths:
           schema:
             $ref: '#/definitions/response.ResponseMessage'
       summary: Set guild default ticker
+      tags:
+      - ConfigDefi
+  /config-defi/default-ticker/{guild_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get list default ticker of a guild.
+      parameters:
+      - description: Guild ID
+        in: path
+        name: guild_id
+        required: true
+        type: string
+      - description: Guild ticker query
+        in: query
+        name: query
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.GetListGuildDefaultTickerResponse'
+      summary: Get list default ticker of a guild.
       tags:
       - ConfigDefi
   /config-defi/monikers:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3491,13 +3491,13 @@ definitions:
         type: string
       usd:
         type: number
-      usd_1h_change:
-        type: number
-      usd_1y_change:
-        type: number
       usd_7d_change:
         type: number
       usd_14d_change:
+        type: number
+      usd_1h_change:
+        type: number
+      usd_1y_change:
         type: number
       usd_24h_change:
         type: number
@@ -4260,6 +4260,12 @@ definitions:
         additionalProperties:
           type: number
         type: object
+      price_change_percentage_7d:
+        type: number
+      price_change_percentage_7d_in_currency:
+        additionalProperties:
+          type: number
+        type: object
       price_change_percentage_14d:
         type: number
       price_change_percentage_14d_in_currency:
@@ -4273,12 +4279,6 @@ definitions:
       price_change_percentage_1y:
         type: number
       price_change_percentage_1y_in_currency:
-        additionalProperties:
-          type: number
-        type: object
-      price_change_percentage_7d:
-        type: number
-      price_change_percentage_7d_in_currency:
         additionalProperties:
           type: number
         type: object
@@ -6602,11 +6602,6 @@ paths:
       - description: Guild ID
         in: path
         name: guild_id
-        required: true
-        type: string
-      - description: Guild ticker query
-        in: query
-        name: query
         required: true
         type: string
       produces:

--- a/pkg/entities/defi.go
+++ b/pkg/entities/defi.go
@@ -427,6 +427,15 @@ func (e *Entity) GetGuildDefaultTicker(req request.GetGuildDefaultTickerRequest)
 	return defaultTicker, nil
 }
 
+func (e *Entity) GetListGuildDefaultTicker(guildID string) ([]model.GuildConfigDefaultTicker, error) {
+  configs, err := e.repo.GuildConfigDefaultTicker.GetList(guildID)
+	if err != nil {
+		e.log.Fields(logger.Fields{"guild_id": guildID}).Error(err, "[entity.GetListGuildDefaultTicker] repo.GuildConfigDefaultTicker.GetList() failed")
+		return nil, err
+	}
+	return configs, nil
+}
+
 func (e *Entity) GetUserWatchlist(req request.GetUserWatchlistRequest) (*response.GetWatchlistResponse, error) {
 	q := userwatchlistitem.UserWatchlistQuery{
 		UserID:      req.UserID,

--- a/pkg/handler/config-defi/config.go
+++ b/pkg/handler/config-defi/config.go
@@ -169,6 +169,27 @@ func (h *Handler) GetGuildDefaultTicker(c *gin.Context) {
 	c.JSON(http.StatusOK, response.CreateResponse(res, nil, nil, nil))
 }
 
+// GetListGuildDefaultTicker     godoc
+// @Summary     Get list default ticker of a guild.
+// @Description Get list default ticker of a guild.
+// @Tags        ConfigDefi
+// @Accept      json
+// @Produce     json
+// @Param       guild_id   path  string true  "Guild ID"
+// @Param       query   query  string true  "Guild ticker query"
+// @Success     200 {object} response.GetListGuildDefaultTickerResponse
+// @Router      /config-defi/default-ticker/{guild_id} [get]
+func (h *Handler) GetListGuildDefaultTicker(c *gin.Context) {
+  guildID := c.Param("guild_id")
+	res, err := h.entities.GetListGuildDefaultTicker(guildID)
+	if err != nil {
+    h.log.Fields(logger.Fields{"guildID": guildID}).Error(err, "[handler.GetListGuildDefaultTicker] entity.GetListGuildDefaultTicker() failed")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+	c.JSON(http.StatusOK, response.CreateResponse(res, nil, nil, nil))
+}
+
 // GetGuildtokens     godoc
 // @Summary     Get guild tokens
 // @Description Get guild tokens

--- a/pkg/handler/config-defi/config.go
+++ b/pkg/handler/config-defi/config.go
@@ -176,7 +176,6 @@ func (h *Handler) GetGuildDefaultTicker(c *gin.Context) {
 // @Accept      json
 // @Produce     json
 // @Param       guild_id   path  string true  "Guild ID"
-// @Param       query   query  string true  "Guild ticker query"
 // @Success     200 {object} response.GetListGuildDefaultTickerResponse
 // @Router      /config-defi/default-ticker/{guild_id} [get]
 func (h *Handler) GetListGuildDefaultTicker(c *gin.Context) {

--- a/pkg/handler/config-defi/interface.go
+++ b/pkg/handler/config-defi/interface.go
@@ -12,7 +12,7 @@ type IHandler interface {
 	GetGuildDefaultTicker(c *gin.Context)
 
 	GetGuildTokens(c *gin.Context)
-  GetListGuildDefaultTicker(c *gin.Context)
+	GetListGuildDefaultTicker(c *gin.Context)
 	UpsertGuildTokenConfig(c *gin.Context)
 
 	GetDefaultToken(c *gin.Context)

--- a/pkg/handler/config-defi/interface.go
+++ b/pkg/handler/config-defi/interface.go
@@ -12,6 +12,7 @@ type IHandler interface {
 	GetGuildDefaultTicker(c *gin.Context)
 
 	GetGuildTokens(c *gin.Context)
+  GetListGuildDefaultTicker(c *gin.Context)
 	UpsertGuildTokenConfig(c *gin.Context)
 
 	GetDefaultToken(c *gin.Context)

--- a/pkg/repo/guild_config_default_ticker/pg.go
+++ b/pkg/repo/guild_config_default_ticker/pg.go
@@ -32,3 +32,8 @@ func (pg *pg) UpsertOne(config *model.GuildConfigDefaultTicker) error {
 	}
 	return tx.Commit().Error
 }
+
+	func (pg *pg) GetList(guildID string) ([]model.GuildConfigDefaultTicker, error) {
+    var configs []model.GuildConfigDefaultTicker
+    return configs, pg.db.Table("guild_config_default_ticker").Where("guild_id = ?", guildID).Find(&configs).Error
+  }

--- a/pkg/repo/guild_config_default_ticker/pg.go
+++ b/pkg/repo/guild_config_default_ticker/pg.go
@@ -33,7 +33,7 @@ func (pg *pg) UpsertOne(config *model.GuildConfigDefaultTicker) error {
 	return tx.Commit().Error
 }
 
-	func (pg *pg) GetList(guildID string) ([]model.GuildConfigDefaultTicker, error) {
-    var configs []model.GuildConfigDefaultTicker
-    return configs, pg.db.Table("guild_config_default_ticker").Where("guild_id = ?", guildID).Find(&configs).Error
-  }
+func (pg *pg) GetList(guildID string) ([]model.GuildConfigDefaultTicker, error) {
+	var configs []model.GuildConfigDefaultTicker
+	return configs, pg.db.Table("guild_config_default_ticker").Where("guild_id = ?", guildID).Find(&configs).Error
+}

--- a/pkg/repo/guild_config_default_ticker/store.go
+++ b/pkg/repo/guild_config_default_ticker/store.go
@@ -5,4 +5,5 @@ import "github.com/defipod/mochi/pkg/model"
 type Store interface {
 	GetOneByGuildIDAndQuery(guildID, query string) (*model.GuildConfigDefaultTicker, error)
 	UpsertOne(config *model.GuildConfigDefaultTicker) error
+	GetList(guildID string) ([]model.GuildConfigDefaultTicker, error)
 }

--- a/pkg/response/nft.go
+++ b/pkg/response/nft.go
@@ -257,6 +257,10 @@ type GetGuildDefaultTickerResponse struct {
 	Data *model.GuildConfigDefaultTicker `json:"data"`
 }
 
+type GetListGuildDefaultTickerResponse struct {
+	Data []model.GuildConfigDefaultTicker `json:"data"`
+}
+
 type CreateNFTCollectionResponse struct {
 	Data *model.NFTCollection `json:"data"`
 }

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -380,6 +380,7 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 		defaultTickerGroup := configDefiGroup.Group("/default-ticker")
 		{
 			defaultTickerGroup.GET("", h.ConfigDefi.GetGuildDefaultTicker)
+      defaultTickerGroup.GET("/:guild_id", h.ConfigDefi.GetListGuildDefaultTicker)
 			defaultTickerGroup.POST("", h.ConfigDefi.SetGuildDefaultTicker)
 		}
 		monikerGroup := configDefiGroup.Group("/monikers")


### PR DESCRIPTION
**What does this PR do?**

-   [x] API get list default ticker of a guild

**How to test**

```sh
curl -X 'GET' \
  'http://localhost:8200/api/v1/config-defi/default-ticker/1003627546014916688' \
  -H 'accept: application/json'
```

**Media (Loom or gif)**

<img width="1426" alt="CleanShot 2023-06-14 at 14 28 11@2x" src="https://github.com/consolelabs/mochi-api/assets/14150687/e15521b7-6761-40b9-83fb-ac01c63f8146">

