### PR TITLE
fix: top users response

### DIFF
--- a/pkg/entities/configs.go
+++ b/pkg/entities/configs.go
@@ -259,7 +259,7 @@ func (e *Entity) checkRoleIDInDefaultRole(guildID, roleID string) error {
 }
 
 func (e *Entity) GetUserRoleByLevel(guildID string, level int) (string, error) {
-	config, err := e.repo.GuildConfigLevelRole.GetHighest(guildID, level)
+	config, err := e.repo.GuildConfigLevelRole.GetCurrentLevelRole(guildID, level)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/entities/configs_test.go
+++ b/pkg/entities/configs_test.go
@@ -138,9 +138,9 @@ func TestEntity_GetUserRoleByLevel(t *testing.T) {
 			MinXP: 100,
 		},
 	}
-	guildConfigLR.EXPECT().GetHighest("863278424433229854", 3).Return(&config, nil).AnyTimes()
-	guildConfigLR.EXPECT().GetHighest("863278424433229abc", gomock.Any()).Return(nil, errors.New("invalid guild id")).AnyTimes()
-	guildConfigLR.EXPECT().GetHighest(gomock.Any(), 1).Return(nil, gorm.ErrRecordNotFound)
+	guildConfigLR.EXPECT().GetCurrentLevelRole("863278424433229854", 3).Return(&config, nil).AnyTimes()
+	guildConfigLR.EXPECT().GetCurrentLevelRole("863278424433229abc", gomock.Any()).Return(nil, errors.New("invalid guild id")).AnyTimes()
+	guildConfigLR.EXPECT().GetCurrentLevelRole(gomock.Any(), 1).Return(nil, gorm.ErrRecordNotFound)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &Entity{

--- a/pkg/entities/user.go
+++ b/pkg/entities/user.go
@@ -359,6 +359,15 @@ func (e *Entity) GetTopUsers(guildID, userID, query, sort string, limit, page in
 		return nil, err
 	}
 
+	currentLr, err := e.repo.GuildConfigLevelRole.GetCurrentLevelRole(guildID, author.Level)
+	if err == nil {
+		author.CurrentLevelRole = currentLr
+	}
+	nextLr, _ := e.repo.GuildConfigLevelRole.GetNextLevelRole(guildID, author.Level)
+	if err == nil {
+		author.NextLevelRole = nextLr
+	}
+
 	total, err := e.repo.GuildUserXP.GetTotalTopUsersCount(guildID, query)
 	if err != nil {
 		return nil, err

--- a/pkg/handler/user/testdata/users/200-top-users.json
+++ b/pkg/handler/user/testdata/users/200-top-users.json
@@ -14,7 +14,7 @@
       "guild": {
         "id": "552427722551459840",
         "name": "bestKN",
-        "bot_scopes": [ "*" ],
+        "bot_scopes": ["*"],
         "alias": "",
         "roles": null,
         "created_at": "2022-04-20T16:36:20.014Z",
@@ -22,6 +22,8 @@
         "log_channel": "1016561468369551370",
         "active": true
       },
+      "current_level_role": null,
+      "next_level_role": null,
       "guild_rank": 1,
       "nr_of_actions": 1,
       "progress": 0
@@ -42,7 +44,7 @@
               "invited_by": "",
               "joined_at": "0001-01-01T00:00:00Z",
               "nickname": "bien",
-              "roles": [ ],
+              "roles": [],
               "user_id": "393034938028392449"
             }
           ],
@@ -53,7 +55,9 @@
         "guild": null,
         "guild_rank": 1,
         "nr_of_actions": 1,
-        "progress": 0.35
+        "progress": 0.35,
+        "current_level_role": null,
+        "next_level_role": null
       }
     ]
   }

--- a/pkg/model/guild_user_xp.go
+++ b/pkg/model/guild_user_xp.go
@@ -1,13 +1,15 @@
 package model
 
 type GuildUserXP struct {
-	GuildID     string        `json:"guild_id"`
-	UserID      string        `json:"user_id"`
-	TotalXP     int           `json:"total_xp"`
-	Level       int           `json:"level"`
-	User        *User         `json:"user" gorm:"foreignKey:UserID"`
-	Guild       *DiscordGuild `json:"guild" gorm:"foreignKey:GuildID"`
-	GuildRank   int           `json:"guild_rank"`
-	NrOfActions int           `json:"nr_of_actions"`
-	Progress    float64       `json:"progress" gorm:"-"`
+	GuildID          string                `json:"guild_id"`
+	UserID           string                `json:"user_id"`
+	TotalXP          int                   `json:"total_xp"`
+	Level            int                   `json:"level"`
+	User             *User                 `json:"user" gorm:"foreignKey:UserID"`
+	Guild            *DiscordGuild         `json:"guild" gorm:"foreignKey:GuildID"`
+	GuildRank        int                   `json:"guild_rank"`
+	NrOfActions      int                   `json:"nr_of_actions"`
+	Progress         float64               `json:"progress" gorm:"-"`
+	CurrentLevelRole *GuildConfigLevelRole `json:"current_level_role" gorm:"-"`
+	NextLevelRole    *GuildConfigLevelRole `json:"next_level_role" gorm:"-"`
 }

--- a/pkg/repo/guild_config_level_role/mocks/store.go
+++ b/pkg/repo/guild_config_level_role/mocks/store.go
@@ -78,19 +78,34 @@ func (mr *MockStoreMockRecorder) GetByRoleID(guildID, roleID interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByRoleID", reflect.TypeOf((*MockStore)(nil).GetByRoleID), guildID, roleID)
 }
 
-// GetHighest mocks base method.
-func (m *MockStore) GetHighest(guildID string, level int) (*model.GuildConfigLevelRole, error) {
+// GetCurrentLevelRole mocks base method.
+func (m *MockStore) GetCurrentLevelRole(guildID string, level int) (*model.GuildConfigLevelRole, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHighest", guildID, level)
+	ret := m.ctrl.Call(m, "GetCurrentLevelRole", guildID, level)
 	ret0, _ := ret[0].(*model.GuildConfigLevelRole)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetHighest indicates an expected call of GetHighest.
-func (mr *MockStoreMockRecorder) GetHighest(guildID, level interface{}) *gomock.Call {
+// GetCurrentLevelRole indicates an expected call of GetCurrentLevelRole.
+func (mr *MockStoreMockRecorder) GetCurrentLevelRole(guildID, level interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHighest", reflect.TypeOf((*MockStore)(nil).GetHighest), guildID, level)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentLevelRole", reflect.TypeOf((*MockStore)(nil).GetCurrentLevelRole), guildID, level)
+}
+
+// GetNextLevelRole mocks base method.
+func (m *MockStore) GetNextLevelRole(guildID string, currentLevel int) (*model.GuildConfigLevelRole, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNextLevelRole", guildID, currentLevel)
+	ret0, _ := ret[0].(*model.GuildConfigLevelRole)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNextLevelRole indicates an expected call of GetNextLevelRole.
+func (mr *MockStoreMockRecorder) GetNextLevelRole(guildID, currentLevel interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextLevelRole", reflect.TypeOf((*MockStore)(nil).GetNextLevelRole), guildID, currentLevel)
 }
 
 // UpsertOne mocks base method.

--- a/pkg/repo/guild_config_level_role/pg.go
+++ b/pkg/repo/guild_config_level_role/pg.go
@@ -17,9 +17,12 @@ func NewPG(db *gorm.DB) *pg {
 	}
 }
 
-func (pg *pg) GetHighest(guildID string, level int) (*model.GuildConfigLevelRole, error) {
-	config := &model.GuildConfigLevelRole{}
-	return config, pg.db.Where("guild_id = ? AND level <= ?", guildID, level).Order("level DESC").First(config).Error
+func (pg *pg) GetCurrentLevelRole(guildID string, level int) (cfg *model.GuildConfigLevelRole, err error) {
+	return cfg, pg.db.Where("guild_id = ? AND level <= ?", guildID, level).Order("level DESC").Preload("LevelConfig").First(&cfg).Error
+}
+
+func (pg *pg) GetNextLevelRole(guildID string, currentLevel int) (cfg *model.GuildConfigLevelRole, err error) {
+	return cfg, pg.db.Where("guild_id = ? AND level > ?", guildID, currentLevel).Order("level ASC").Preload("LevelConfig").First(&cfg).Error
 }
 
 func (pg *pg) GetByGuildID(guildID string) ([]model.GuildConfigLevelRole, error) {

--- a/pkg/repo/guild_config_level_role/store.go
+++ b/pkg/repo/guild_config_level_role/store.go
@@ -3,7 +3,8 @@ package guild_config_level_role
 import "github.com/defipod/mochi/pkg/model"
 
 type Store interface {
-	GetHighest(guildID string, level int) (*model.GuildConfigLevelRole, error)
+	GetCurrentLevelRole(guildID string, level int) (*model.GuildConfigLevelRole, error)
+	GetNextLevelRole(guildID string, currentLevel int) (*model.GuildConfigLevelRole, error)
 	GetByGuildID(guildID string) ([]model.GuildConfigLevelRole, error)
 	GetByRoleID(guildID, roleID string) (*model.GuildConfigLevelRole, error)
 	UpsertOne(config model.GuildConfigLevelRole) error


### PR DESCRIPTION
**What does this PR do?**
-   [x] Update `/api/v1/users/topAdd`: additional info - `currentLevelRole` and `nextLevelRole`
