### PR TITLE
feat: add product changelogs view

### DIFF
--- a/migrations/schemas/20230828140930-alter_product_changelogs.sql
+++ b/migrations/schemas/20230828140930-alter_product_changelogs.sql
@@ -1,0 +1,4 @@
+-- +migrate Up
+alter table product_changelogs add column file_name text;
+-- +migrate Down
+alter table product_changelogs drop column file_name;

--- a/migrations/schemas/20230828141030-add_product_changelog_views.sql
+++ b/migrations/schemas/20230828141030-add_product_changelog_views.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+create table product_changelog_views  (
+     id SERIAL PRIMARY KEY,
+     key text,
+     changelog_name text,
+     metadata json,
+     created_at timestamp not null default now(),
+     updated_at timestamp not null default now()
+);
+
+-- +migrate Down
+drop table product_changelog_views;
+

--- a/pkg/entities/product_data.go
+++ b/pkg/entities/product_data.go
@@ -9,6 +9,7 @@ import (
 	"github.com/defipod/mochi/pkg/model"
 	productbotcommand "github.com/defipod/mochi/pkg/repo/product_bot_command"
 	productchangelogs "github.com/defipod/mochi/pkg/repo/product_changelogs"
+	productchangelogsview "github.com/defipod/mochi/pkg/repo/product_changelogs_view"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/util"
 )
@@ -24,6 +25,23 @@ func (e *Entity) ProductChangelogs(req request.ProductChangelogsRequest) ([]mode
 	return e.repo.ProductChangelogs.List(productchangelogs.ListQuery{
 		Product: req.Product,
 		Size:    req.Size,
+	})
+}
+
+func (e *Entity) CreateProductChangelogsView(req request.CreateProductChangelogsViewRequest) (*model.ProductChangelogView, error) {
+	productchangelogsview := &model.ProductChangelogView{
+		Key:           req.Key,
+		ChangelogName: req.ChangelogName,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+	return productchangelogsview, e.repo.ProductChangelogsView.Create(productchangelogsview)
+}
+
+func (e *Entity) GetProductChangelogsView(req request.GetProductChangelogsViewRequest) ([]model.ProductChangelogView, error) {
+	return e.repo.ProductChangelogsView.List(productchangelogsview.ListQuery{
+		Key:           req.Key,
+		ChangelogName: req.ChangelogName,
 	})
 }
 
@@ -61,6 +79,7 @@ func (e *Entity) CrawlChangelogs() {
 			continue
 		}
 		changelogs.GithubUrl = repo.HTMLURL
+		changelogs.FileName = repo.Name
 
 		// 5. store changelogs
 		err = e.repo.ProductChangelogs.Create(changelogs)

--- a/pkg/handler/api-key/interface.go
+++ b/pkg/handler/api-key/interface.go
@@ -5,5 +5,5 @@ import "github.com/gin-gonic/gin"
 type IHandler interface {
 	CreateApiKey(c *gin.Context)
 	IntegrateBinanceKey(c *gin.Context)
-  UnlinkBinance(c *gin.Context)
+	UnlinkBinance(c *gin.Context)
 }

--- a/pkg/handler/product-data/interface.go
+++ b/pkg/handler/product-data/interface.go
@@ -6,4 +6,6 @@ type IHandler interface {
 	ProductBotCommand(c *gin.Context)
 	ProductChangelogs(c *gin.Context)
 	CrawlChangelogs(c *gin.Context)
+	CreateProductChangelogsView(c *gin.Context)
+	GetProductChangelogsView(c *gin.Context)
 }

--- a/pkg/handler/product-data/product_data.go
+++ b/pkg/handler/product-data/product_data.go
@@ -76,6 +76,56 @@ func (h *Handler) ProductChangelogs(c *gin.Context) {
 	c.JSON(http.StatusOK, response.CreateResponse(productChangelogs, nil, nil, nil))
 }
 
+// CreateProductChangelogsView   godoc
+// @Summary     Created product changelogs viewed
+// @Description Created product changelogs viewed
+// @Tags        ProductMetadata
+// @Accept      json
+// @Produce     json
+// @Param       req   body  request.CreateProductChangelogsViewRequest true  "create product changelogs viewed request"
+// @Success     200 {object} response.CreateProductChangelogsView
+// @Router      /product-metadata/changelogs/view [post]
+func (h *Handler) CreateProductChangelogsView(c *gin.Context) {
+	req := request.CreateProductChangelogsViewRequest{}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.log.Error(err, "[handler.CreateProductChangelogsView] BindJSON() failed")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+
+	productChangelogsView, err := h.entities.CreateProductChangelogsView(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, response.CreateResponse(productChangelogsView, nil, nil, nil))
+}
+
+// GetProductChangelogsView     godoc
+// @Summary     Get product changelogs viewed
+// @Description Get product changelogs viewed
+// @Tags        ProductMetadata
+// @Accept      json
+// @Produce     json
+// @Param       req   query  request.GetProductChangelogsViewRequest  false  "get product changelogs viewed request"
+// @Success     200 {object} response.GetProductChangelogsView
+// @Router      /product-metadata/changelogs/view [get]
+func (h *Handler) GetProductChangelogsView(c *gin.Context) {
+	req := request.GetProductChangelogsViewRequest{}
+	if err := c.BindQuery(&req); err != nil {
+		h.log.Error(err, "[handler.GetProductChangelogsView] BindQuery() failed")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+
+	productChangelogsViews, err := h.entities.GetProductChangelogsView(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, response.CreateResponse(productChangelogsViews, nil, nil, nil))
+}
+
 func (h *Handler) CrawlChangelogs(c *gin.Context) {
 	go h.entities.CrawlChangelogs()
 	c.JSON(http.StatusOK, response.CreateResponse(map[string]string{"message": "ok"}, nil, nil, nil))

--- a/pkg/model/product_bot_commands.go
+++ b/pkg/model/product_bot_commands.go
@@ -25,6 +25,15 @@ type ProductChangelogs struct {
 	Content      string    `json:"content"`
 	GithubUrl    string    `json:"github_url"`
 	ThumbnailUrl string    `json:"thumbnail_url"`
+	FileName     string    `json:"file_name"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+type ProductChangelogView struct {
+	Key           string    `json:"key"`
+	ChangelogName string    `json:"changelog_name"`
+	Metadata      *[]byte   `json:"metadata" gorm:"metadata type:jsonb;default:'[]';not null"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }

--- a/pkg/repo/pg/repo.go
+++ b/pkg/repo/pg/repo.go
@@ -56,6 +56,7 @@ import (
 	offchaintipbottokens "github.com/defipod/mochi/pkg/repo/offchain_tip_bot_tokens"
 	productbotcommand "github.com/defipod/mochi/pkg/repo/product_bot_command"
 	productchangelogs "github.com/defipod/mochi/pkg/repo/product_changelogs"
+	productchangelogsview "github.com/defipod/mochi/pkg/repo/product_changelogs_view"
 	pac "github.com/defipod/mochi/pkg/repo/profile_airdrop_campaign"
 	"github.com/defipod/mochi/pkg/repo/quest"
 	questpass "github.com/defipod/mochi/pkg/repo/quest_pass"
@@ -170,5 +171,6 @@ func NewRepo(db *gorm.DB) *repo.Repo {
 		TokenInfo:                            tokeninfo.NewPG(db),
 		ProductBotCommand:                    productbotcommand.NewPG(db),
 		ProductChangelogs:                    productchangelogs.NewPG(db),
+		ProductChangelogsView:                productchangelogsview.NewPG(db),
 	}
 }

--- a/pkg/repo/product_changelogs_view/pg.go
+++ b/pkg/repo/product_changelogs_view/pg.go
@@ -1,0 +1,33 @@
+package product_changelogs_view
+
+import (
+	"gorm.io/gorm"
+	"strings"
+
+	"github.com/defipod/mochi/pkg/model"
+)
+
+type pg struct {
+	db *gorm.DB
+}
+
+func NewPG(db *gorm.DB) Store {
+	return &pg{db: db}
+}
+
+func (pg *pg) List(q ListQuery) (changeLogsView []model.ProductChangelogView, err error) {
+	db := pg.db
+	if q.Key != "" {
+		db = db.Where("lower(key) = ?", strings.ToLower(q.Key))
+	}
+	if q.ChangelogName != "" {
+		db = db.Where("lower(changelog_name) = ?", strings.ToLower(q.ChangelogName))
+	}
+
+	return changeLogsView, db.Order("created_at DESC").Find(&changeLogsView).Error
+}
+
+func (pg *pg) Create(changeLogsView *model.ProductChangelogView) error {
+	db := pg.db
+	return db.Create(changeLogsView).Error
+}

--- a/pkg/repo/product_changelogs_view/query.go
+++ b/pkg/repo/product_changelogs_view/query.go
@@ -1,0 +1,6 @@
+package product_changelogs_view
+
+type ListQuery struct {
+	Key           string
+	ChangelogName string
+}

--- a/pkg/repo/product_changelogs_view/store.go
+++ b/pkg/repo/product_changelogs_view/store.go
@@ -1,0 +1,8 @@
+package product_changelogs_view
+
+import "github.com/defipod/mochi/pkg/model"
+
+type Store interface {
+	List(ListQuery) ([]model.ProductChangelogView, error)
+	Create(changelogView *model.ProductChangelogView) error
+}

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -53,6 +53,7 @@ import (
 	offchaintipbottokens "github.com/defipod/mochi/pkg/repo/offchain_tip_bot_tokens"
 	productbotcommand "github.com/defipod/mochi/pkg/repo/product_bot_command"
 	productchangelogs "github.com/defipod/mochi/pkg/repo/product_changelogs"
+	productchangelogsview "github.com/defipod/mochi/pkg/repo/product_changelogs_view"
 	pac "github.com/defipod/mochi/pkg/repo/profile_airdrop_campaign"
 	"github.com/defipod/mochi/pkg/repo/quest"
 	questpass "github.com/defipod/mochi/pkg/repo/quest_pass"
@@ -165,4 +166,5 @@ type Repo struct {
 	TokenInfo                            tokeninfo.Store
 	ProductBotCommand                    productbotcommand.Store
 	ProductChangelogs                    productchangelogs.Store
+	ProductChangelogsView                productchangelogsview.Store
 }

--- a/pkg/request/product_data.go
+++ b/pkg/request/product_data.go
@@ -9,3 +9,13 @@ type ProductChangelogsRequest struct {
 	Product string `form:"product"`
 	Size    string `form:"size"`
 }
+
+type CreateProductChangelogsViewRequest struct {
+	Key           string `json:"key"`
+	ChangelogName string `json:"changelog_name"`
+}
+
+type GetProductChangelogsViewRequest struct {
+	Key           string `form:"key"`
+	ChangelogName string `form:"changelog_name"`
+}

--- a/pkg/response/product_metadata.go
+++ b/pkg/response/product_metadata.go
@@ -9,3 +9,11 @@ type ProductBotCommand struct {
 type ProductChangelogs struct {
 	Data []model.ProductChangelogs `json:"data"`
 }
+
+type CreateProductChangelogsViewed struct {
+	Data model.ProductChangelogView `json:"data"`
+}
+
+type GetProductChangelogsViewed struct {
+	Data []model.ProductChangelogView `json:"data"`
+}

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -411,6 +411,8 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 		productMetaData.GET("/copy/:type", h.Content.GetTypeContent)
 		productMetaData.GET("/commands", h.ProductData.ProductBotCommand)
 		productMetaData.GET("/changelogs", h.ProductData.ProductChangelogs)
+		productMetaData.POST("/changelogs/view", h.ProductData.CreateProductChangelogsView)
+		productMetaData.GET("/changelogs/view", h.ProductData.GetProductChangelogsView)
 		productMetaData.GET("/crawl-changelogs", h.ProductData.CrawlChangelogs)
 	}
 


### PR DESCRIPTION
## What's this PR does ?

-   [x] Add product changelogs view
-   [x] Add `file_name` field for `product_changelogs` table
-   [x] No UI commands affect by this change

**How to test**
-  [x] Create product changelogs view record
```sh
curl --request POST 'http://localhost:8200/api/v1/product-metadata/changelogs/view' \
--header 'Content-Type: application/json' \
--data '{
    "profile_id": "1677175883678355456",
    "changelog_name": "2023-19-08.md"
}'
```

-  [x] get product changelogs view
```sh
curl --request GET 'http://localhost:8200/api/v1/product-metadata/changelogs/view?changelog_name=2023-19-08.md' \
--header 'Content-Type: application/json'
```