### PR TITLE
fix: produce kafka message using buildin utility

### DIFF
--- a/pkg/kafka/producer.go
+++ b/pkg/kafka/producer.go
@@ -108,14 +108,16 @@ func (q *Kafka) ProduceNotification(topic string, value []byte) error {
 		return fmt.Errorf("producer is not ready")
 	}
 
-	q.producer.producer.ProduceChannel() <- &kafka.Message{
-		TopicPartition: kafka.TopicPartition{
-			Topic:     &topic,
-			Partition: kafka.PartitionAny,
-		},
-		Value: value,
-		Key:   []byte(strconv.Itoa(rand.Intn(100000))),
-	}
+	q.producer.producer.Produce(
+		&kafka.Message{
+			TopicPartition: kafka.TopicPartition{
+				Topic:     &topic,
+				Partition: kafka.PartitionAny,
+			},
+			Value: value,
+			Key:   []byte(strconv.Itoa(rand.Intn(100000))),
+		}, nil,
+	)
 
 	q.producer.producer.Flush(15 * 1000)
 


### PR DESCRIPTION
## What's this PR does ?

nếu push trực tiếp vào thì sẽ bị mất message (thường là message cuối) vì nếu Flush mà message chưa kịp vào channel -> ko có gì để flush
