### PR TITLE
feat: add tracking key price change percentage

### DIFF
--- a/pkg/handler/defi/defi.go
+++ b/pkg/handler/defi/defi.go
@@ -712,6 +712,15 @@ func (h *Handler) TrackFriendTechKey(c *gin.Context) {
 		keyMetadata = &searchKeyResult.Data[0]
 	}
 
+	if keyMetadata != nil {
+		keyMetadata.PriceChangePercentage, err = h.entities.CalculateFriendTechKeyPriceChangePercentage(data.KeyAddress)
+		if err != nil {
+			h.log.Error(err, "[handler.TrackFriendTechKey] entities.CalculateFriendTechKeyPriceChangePercentage() failed")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
 	c.JSON(http.StatusOK, response.CreateResponse(response.TrackingFriendTechKeyModelToResponse(
 		*data,
 		keyMetadata,
@@ -795,6 +804,15 @@ func (h *Handler) UpdateFriendTechKeyTrack(c *gin.Context) {
 		keyMetadata = &searchKeyResult.Data[0]
 	}
 
+	if keyMetadata != nil {
+		keyMetadata.PriceChangePercentage, err = h.entities.CalculateFriendTechKeyPriceChangePercentage(updatedTrack.KeyAddress)
+		if err != nil {
+			h.log.Error(err, "[handler.UpdateFriendTechKeyTrack] entities.CalculateFriendTechKeyPriceChangePercentage() failed")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
 	c.JSON(http.StatusOK, response.CreateResponse(response.TrackingFriendTechKeyModelToResponse(
 		*updatedTrack,
 		keyMetadata,
@@ -841,6 +859,15 @@ func (h *Handler) GetUserFriendTechKeyWatchlist(c *gin.Context) {
 		var keyMetadata *response.FriendTechKey
 		if len(searchKeyResult.Data) > 0 && strings.EqualFold(searchKeyResult.Data[0].Address, trackingKey.KeyAddress) {
 			keyMetadata = &searchKeyResult.Data[0]
+		}
+
+		if keyMetadata != nil {
+			keyMetadata.PriceChangePercentage, err = h.entities.CalculateFriendTechKeyPriceChangePercentage(trackingKey.KeyAddress)
+			if err != nil {
+				h.log.Error(err, "[handler.TrackFriendTechKey] entities.CalculateFriendTechKeyPriceChangePercentage() failed")
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
 		}
 
 		resp = append(resp, *response.TrackingFriendTechKeyModelToResponse(trackingKey, keyMetadata))

--- a/pkg/response/friend_tech.go
+++ b/pkg/response/friend_tech.go
@@ -13,16 +13,17 @@ type FriendTechKeysResponse struct {
 }
 
 type FriendTechKey struct {
-	ID              int64     `json:"id"`
-	CreatedAt       time.Time `json:"createdAt"`
-	UpdatedAt       time.Time `json:"updatedAt"`
-	Address         string    `json:"address"`
-	TwitterUsername string    `json:"twitterUsername"`
-	TwitterPfpUrl   string    `json:"twitterPfpUrl"`
-	ProfileChecked  bool      `json:"profileChecked"`
-	Price           float64   `json:"price"`
-	Supply          int       `json:"supply"`
-	Holders         int       `json:"holders"`
+	ID                    int64     `json:"id"`
+	CreatedAt             time.Time `json:"createdAt"`
+	UpdatedAt             time.Time `json:"updatedAt"`
+	Address               string    `json:"address"`
+	TwitterUsername       string    `json:"twitterUsername"`
+	TwitterPfpUrl         string    `json:"twitterPfpUrl"`
+	ProfileChecked        bool      `json:"profileChecked"`
+	Price                 float64   `json:"price"`
+	Supply                int       `json:"supply"`
+	Holders               int       `json:"holders"`
+	PriceChangePercentage float64   `json:"priceChangePercentage"`
 }
 
 type GetUserFriendTechKeyWatchlistResponse struct {


### PR DESCRIPTION
Update 3 APIs `GET/POST/PUT /tracking-keys` for returning the 24h price change percentage
![image](https://github.com/consolelabs/mochi-api/assets/32956772/784f5a00-0420-4d20-8a9d-390bb158c6a2)
