### PR TITLE
fix: cache profile cmd - grouped by platform

### DIFF
--- a/pkg/model/profile_command_usage.go
+++ b/pkg/model/profile_command_usage.go
@@ -16,4 +16,5 @@ type CommandUsageCounter struct {
 	TotalUsage     int64
 	ProfileId      string
 	UserPlatformId string
+	Platform       string
 }


### PR DESCRIPTION
## What's this PR does ?
- cache profile cmd: need to group by `platform` as well

## Which UI commands affect by this change ?
- /profile
