### PR TITLE
fix: friend tech key api - add client id

### DIFF
--- a/pkg/service/friendtech/friend_tech.go
+++ b/pkg/service/friendtech/friend_tech.go
@@ -6,12 +6,20 @@ import (
 	"net/http"
 
 	"github.com/defipod/mochi/pkg/config"
+	"github.com/defipod/mochi/pkg/consts"
 	"github.com/defipod/mochi/pkg/response"
 	"github.com/defipod/mochi/pkg/util"
 )
 
 type FriendTech struct {
 	baseUrl string
+}
+
+var commonHeader = map[string]string{
+	"Content-Type": "application/json",
+	"Accept":       "application/json",
+	"clientData":   fmt.Sprintf("{\"source\": \"%s\"}", consts.ClientID),
+	"x-client-id":  consts.ClientID,
 }
 
 func NewService(cfg *config.Config) Service {
@@ -35,7 +43,7 @@ func (n *FriendTech) Search(query string, limit int) (*response.FriendTechKeysRe
 	req := util.SendRequestQuery{
 		URL:       url,
 		ParseForm: &data,
-		Headers:   map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+		Headers:   commonHeader,
 	}
 	statusCode, err := util.SendRequest(req)
 	if err != nil || statusCode != http.StatusOK {
@@ -50,8 +58,9 @@ func (n *FriendTech) GetHistory(accountAddress, interval string) (*response.Frie
 	req := util.SendRequestQuery{
 		URL:       url,
 		ParseForm: &data,
-		Headers:   map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+		Headers:   commonHeader,
 	}
+
 	statusCode, err := util.SendRequest(req)
 	if err != nil || statusCode != http.StatusOK {
 		return &response.FriendTechKeyPriceHistoryResponse{}, nil
@@ -70,7 +79,7 @@ func (n *FriendTech) GetTransactions(subjectAddress string, limit int) (*respons
 	req := util.SendRequestQuery{
 		URL:       url,
 		ParseForm: &data,
-		Headers:   map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+		Headers:   commonHeader,
 	}
 	statusCode, err := util.SendRequest(req)
 	if err != nil {


### PR DESCRIPTION
## What's this PR does ?

Got error 
```
{"hostname":"track-friend-tech-keys-28284200-pcg6r","level":"info","msg":"discord intents: 64","service":"mochi-api","time":"2023-10-11T19:23:30Z"}
{"hostname":"track-friend-tech-keys-28284200-pcg6r","level":"info","msg":"Connected to discord: Mochi Bot","service":"mochi-api","time":"2023-10-11T19:23:31Z"}
{"hostname":"track-friend-tech-keys-28284200-pcg6r","level":"info","msg":"start tracking friend tech keys","service":"mochi-api","time":"2023-10-11T19:23:33Z"}
{"error":"Get \"https://api.friendscan.tech/transactions?subjectAddress=0xfd7232e66a69e1ae01e1e0ea8fab4776e2d325a9\u0026limit=50\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","keyAddress":"0xfd7232e66a69e1ae01e1e0ea8fab4776e2d325a9","level":"error","limit":50,"msg":"[entity.GetFriendTechKeyTransactions] svc.FriendTech.GetTransactions() failed","time":"2023-10-11T19:24:03Z"}
{"error":"Get \"https://api.friendscan.tech/transactions?subjectAddress=0xfd7232e66a69e1ae01e1e0ea8fab4776e2d325a9\u0026limit=50\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","hostname":"track-friend-tech-keys-28284200-pcg6r","level":"error","msg":"[GetFriendTechKeyTransactions] failed to get transactions","service":"mochi-api","time":"2023-10-11T19:24:03Z"}
{"error":"Get \"https://api.friendscan.tech/transactions?subjectAddress=0xfd7232e66a69e1ae01e1e0ea8fab4776e2d325a9\u0026limit=50\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","hostname":"track-friend-tech-keys-28284200-pcg6r","level":"fatal","msg":"failed to run job","service":"mochi-api","time":"2023-10-11T19:24:03Z"}
Stream closed EOF for mochi-preview/track-friend-tech-keys-28284200-pcg6r (track-friend-tech-keys)
```

I guess it happens because of rate limit. We missed adding client id when calling api. 