### PR TITLE
feat(cmd): add available cmds to discord guild

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6327,44 +6327,6 @@ const docTemplate = `{
                 }
             }
         },
-        "model.AvailableCMD": {
-            "type": "object",
-            "properties": {
-                "application_id": {
-                    "type": "string"
-                },
-                "default_member_permissions": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "description_localizations": {
-                    "type": "string"
-                },
-                "guild_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "name_localizations": {
-                    "type": "string"
-                },
-                "nsfw": {
-                    "type": "boolean"
-                },
-                "type": {
-                    "type": "integer"
-                },
-                "version": {
-                    "type": "string"
-                }
-            }
-        },
         "model.Chain": {
             "type": "object",
             "properties": {
@@ -6560,6 +6522,44 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.DiscordCMD": {
+            "type": "object",
+            "properties": {
+                "application_id": {
+                    "type": "string"
+                },
+                "default_member_permissions": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_localizations": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "name_localizations": {
+                    "type": "string"
+                },
+                "nsfw": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "integer"
+                },
+                "version": {
                     "type": "string"
                 }
             }
@@ -8629,7 +8629,7 @@ const docTemplate = `{
                 "available_cmds": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.AvailableCMD"
+                        "$ref": "#/definitions/model.DiscordCMD"
                     }
                 },
                 "global_xp": {
@@ -10054,7 +10054,7 @@ const docTemplate = `{
                 "available_cmds": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.AvailableCMD"
+                        "$ref": "#/definitions/model.DiscordCMD"
                     }
                 },
                 "bot_scopes": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6535,6 +6535,9 @@ const docTemplate = `{
                 "alias": {
                     "type": "string"
                 },
+                "available_cmds": {
+                    "$ref": "#/definitions/model.JSONNullString"
+                },
                 "bot_scopes": {
                     "type": "array",
                     "items": {
@@ -6924,6 +6927,18 @@ const docTemplate = `{
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "model.JSONNullString": {
+            "type": "object",
+            "properties": {
+                "string": {
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "Valid is true if String is not NULL",
+                    "type": "boolean"
                 }
             }
         },
@@ -7761,6 +7776,44 @@ const docTemplate = `{
                 }
             }
         },
+        "request.AvailableCMD": {
+            "type": "object",
+            "properties": {
+                "application_id": {
+                    "type": "string"
+                },
+                "default_member_permissions": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_localizations": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "name_localizations": {
+                    "type": "string"
+                },
+                "nsfw": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
         "request.ClaimQuestsRewardsRequest": {
             "type": "object",
             "properties": {
@@ -8572,6 +8625,12 @@ const docTemplate = `{
             "properties": {
                 "active": {
                     "type": "boolean"
+                },
+                "available_cmds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/request.AvailableCMD"
+                    }
                 },
                 "global_xp": {
                     "type": "boolean"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6327,6 +6327,44 @@ const docTemplate = `{
                 }
             }
         },
+        "model.AvailableCMD": {
+            "type": "object",
+            "properties": {
+                "application_id": {
+                    "type": "string"
+                },
+                "default_member_permissions": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_localizations": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "name_localizations": {
+                    "type": "string"
+                },
+                "nsfw": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
         "model.Chain": {
             "type": "object",
             "properties": {
@@ -7776,44 +7814,6 @@ const docTemplate = `{
                 }
             }
         },
-        "request.AvailableCMD": {
-            "type": "object",
-            "properties": {
-                "application_id": {
-                    "type": "string"
-                },
-                "default_member_permissions": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "description_localizations": {
-                    "type": "string"
-                },
-                "guild_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "name_localizations": {
-                    "type": "string"
-                },
-                "nsfw": {
-                    "type": "boolean"
-                },
-                "type": {
-                    "type": "integer"
-                },
-                "version": {
-                    "type": "string"
-                }
-            }
-        },
         "request.ClaimQuestsRewardsRequest": {
             "type": "object",
             "properties": {
@@ -8629,7 +8629,7 @@ const docTemplate = `{
                 "available_cmds": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/request.AvailableCMD"
+                        "$ref": "#/definitions/model.AvailableCMD"
                     }
                 },
                 "global_xp": {
@@ -10050,6 +10050,12 @@ const docTemplate = `{
                 },
                 "alias": {
                     "type": "string"
+                },
+                "available_cmds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.AvailableCMD"
+                    }
                 },
                 "bot_scopes": {
                     "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6319,44 +6319,6 @@
                 }
             }
         },
-        "model.AvailableCMD": {
-            "type": "object",
-            "properties": {
-                "application_id": {
-                    "type": "string"
-                },
-                "default_member_permissions": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "description_localizations": {
-                    "type": "string"
-                },
-                "guild_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "name_localizations": {
-                    "type": "string"
-                },
-                "nsfw": {
-                    "type": "boolean"
-                },
-                "type": {
-                    "type": "integer"
-                },
-                "version": {
-                    "type": "string"
-                }
-            }
-        },
         "model.Chain": {
             "type": "object",
             "properties": {
@@ -6552,6 +6514,44 @@
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.DiscordCMD": {
+            "type": "object",
+            "properties": {
+                "application_id": {
+                    "type": "string"
+                },
+                "default_member_permissions": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_localizations": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "name_localizations": {
+                    "type": "string"
+                },
+                "nsfw": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "integer"
+                },
+                "version": {
                     "type": "string"
                 }
             }
@@ -8621,7 +8621,7 @@
                 "available_cmds": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.AvailableCMD"
+                        "$ref": "#/definitions/model.DiscordCMD"
                     }
                 },
                 "global_xp": {
@@ -10046,7 +10046,7 @@
                 "available_cmds": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.AvailableCMD"
+                        "$ref": "#/definitions/model.DiscordCMD"
                     }
                 },
                 "bot_scopes": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6319,6 +6319,44 @@
                 }
             }
         },
+        "model.AvailableCMD": {
+            "type": "object",
+            "properties": {
+                "application_id": {
+                    "type": "string"
+                },
+                "default_member_permissions": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_localizations": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "name_localizations": {
+                    "type": "string"
+                },
+                "nsfw": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
         "model.Chain": {
             "type": "object",
             "properties": {
@@ -7768,44 +7806,6 @@
                 }
             }
         },
-        "request.AvailableCMD": {
-            "type": "object",
-            "properties": {
-                "application_id": {
-                    "type": "string"
-                },
-                "default_member_permissions": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "description_localizations": {
-                    "type": "string"
-                },
-                "guild_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "name_localizations": {
-                    "type": "string"
-                },
-                "nsfw": {
-                    "type": "boolean"
-                },
-                "type": {
-                    "type": "integer"
-                },
-                "version": {
-                    "type": "string"
-                }
-            }
-        },
         "request.ClaimQuestsRewardsRequest": {
             "type": "object",
             "properties": {
@@ -8621,7 +8621,7 @@
                 "available_cmds": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/request.AvailableCMD"
+                        "$ref": "#/definitions/model.AvailableCMD"
                     }
                 },
                 "global_xp": {
@@ -10042,6 +10042,12 @@
                 },
                 "alias": {
                     "type": "string"
+                },
+                "available_cmds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.AvailableCMD"
+                    }
                 },
                 "bot_scopes": {
                     "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6527,6 +6527,9 @@
                 "alias": {
                     "type": "string"
                 },
+                "available_cmds": {
+                    "$ref": "#/definitions/model.JSONNullString"
+                },
                 "bot_scopes": {
                     "type": "array",
                     "items": {
@@ -6916,6 +6919,18 @@
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "model.JSONNullString": {
+            "type": "object",
+            "properties": {
+                "string": {
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "Valid is true if String is not NULL",
+                    "type": "boolean"
                 }
             }
         },
@@ -7753,6 +7768,44 @@
                 }
             }
         },
+        "request.AvailableCMD": {
+            "type": "object",
+            "properties": {
+                "application_id": {
+                    "type": "string"
+                },
+                "default_member_permissions": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_localizations": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "name_localizations": {
+                    "type": "string"
+                },
+                "nsfw": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
         "request.ClaimQuestsRewardsRequest": {
             "type": "object",
             "properties": {
@@ -8564,6 +8617,12 @@
             "properties": {
                 "active": {
                     "type": "boolean"
+                },
+                "available_cmds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/request.AvailableCMD"
+                    }
                 },
                 "global_xp": {
                     "type": "boolean"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -179,6 +179,8 @@ definitions:
         type: boolean
       alias:
         type: string
+      available_cmds:
+        $ref: '#/definitions/model.JSONNullString'
       bot_scopes:
         items:
           type: string
@@ -434,6 +436,14 @@ definitions:
         $ref: '#/definitions/model.User'
       user_id:
         type: string
+    type: object
+  model.JSONNullString:
+    properties:
+      string:
+        type: string
+      valid:
+        description: Valid is true if String is not NULL
+        type: boolean
     type: object
   model.MonikerConfig:
     properties:
@@ -984,6 +994,31 @@ definitions:
     - guild_id
     - user_discord_id
     type: object
+  request.AvailableCMD:
+    properties:
+      application_id:
+        type: string
+      default_member_permissions:
+        type: integer
+      description:
+        type: string
+      description_localizations:
+        type: string
+      guild_id:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      name_localizations:
+        type: string
+      nsfw:
+        type: boolean
+      type:
+        type: integer
+      version:
+        type: string
+    type: object
   request.ClaimQuestsRewardsRequest:
     properties:
       quest_id:
@@ -1520,6 +1555,10 @@ definitions:
     properties:
       active:
         type: boolean
+      available_cmds:
+        items:
+          $ref: '#/definitions/request.AvailableCMD'
+        type: array
       global_xp:
         type: boolean
       left_at:
@@ -3317,6 +3356,12 @@ definitions:
         additionalProperties:
           type: number
         type: object
+      price_change_percentage_1y:
+        type: number
+      price_change_percentage_1y_in_currency:
+        additionalProperties:
+          type: number
+        type: object
       price_change_percentage_7d:
         type: number
       price_change_percentage_7d_in_currency:
@@ -3326,12 +3371,6 @@ definitions:
       price_change_percentage_14d:
         type: number
       price_change_percentage_14d_in_currency:
-        additionalProperties:
-          type: number
-        type: object
-      price_change_percentage_1y:
-        type: number
-      price_change_percentage_1y_in_currency:
         additionalProperties:
           type: number
         type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -43,6 +43,31 @@ definitions:
       status:
         type: string
     type: object
+  model.AvailableCMD:
+    properties:
+      application_id:
+        type: string
+      default_member_permissions:
+        type: integer
+      description:
+        type: string
+      description_localizations:
+        type: string
+      guild_id:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      name_localizations:
+        type: string
+      nsfw:
+        type: boolean
+      type:
+        type: integer
+      version:
+        type: string
+    type: object
   model.Chain:
     properties:
       coin_gecko_id:
@@ -994,31 +1019,6 @@ definitions:
     - guild_id
     - user_discord_id
     type: object
-  request.AvailableCMD:
-    properties:
-      application_id:
-        type: string
-      default_member_permissions:
-        type: integer
-      description:
-        type: string
-      description_localizations:
-        type: string
-      guild_id:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-      name_localizations:
-        type: string
-      nsfw:
-        type: boolean
-      type:
-        type: integer
-      version:
-        type: string
-    type: object
   request.ClaimQuestsRewardsRequest:
     properties:
       quest_id:
@@ -1557,7 +1557,7 @@ definitions:
         type: boolean
       available_cmds:
         items:
-          $ref: '#/definitions/request.AvailableCMD'
+          $ref: '#/definitions/model.AvailableCMD'
         type: array
       global_xp:
         type: boolean
@@ -2485,6 +2485,10 @@ definitions:
         type: boolean
       alias:
         type: string
+      available_cmds:
+        items:
+          $ref: '#/definitions/model.AvailableCMD'
+        type: array
       bot_scopes:
         items:
           type: string
@@ -3350,18 +3354,6 @@ definitions:
         additionalProperties:
           type: number
         type: object
-      price_change_percentage_1h:
-        type: number
-      price_change_percentage_1h_in_currency:
-        additionalProperties:
-          type: number
-        type: object
-      price_change_percentage_1y:
-        type: number
-      price_change_percentage_1y_in_currency:
-        additionalProperties:
-          type: number
-        type: object
       price_change_percentage_7d:
         type: number
       price_change_percentage_7d_in_currency:
@@ -3371,6 +3363,18 @@ definitions:
       price_change_percentage_14d:
         type: number
       price_change_percentage_14d_in_currency:
+        additionalProperties:
+          type: number
+        type: object
+      price_change_percentage_1h:
+        type: number
+      price_change_percentage_1h_in_currency:
+        additionalProperties:
+          type: number
+        type: object
+      price_change_percentage_1y:
+        type: number
+      price_change_percentage_1y_in_currency:
         additionalProperties:
           type: number
         type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -43,31 +43,6 @@ definitions:
       status:
         type: string
     type: object
-  model.AvailableCMD:
-    properties:
-      application_id:
-        type: string
-      default_member_permissions:
-        type: integer
-      description:
-        type: string
-      description_localizations:
-        type: string
-      guild_id:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-      name_localizations:
-        type: string
-      nsfw:
-        type: boolean
-      type:
-        type: integer
-      version:
-        type: string
-    type: object
   model.Chain:
     properties:
       coin_gecko_id:
@@ -196,6 +171,31 @@ definitions:
       type:
         type: string
       updated_at:
+        type: string
+    type: object
+  model.DiscordCMD:
+    properties:
+      application_id:
+        type: string
+      default_member_permissions:
+        type: integer
+      description:
+        type: string
+      description_localizations:
+        type: string
+      guild_id:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      name_localizations:
+        type: string
+      nsfw:
+        type: boolean
+      type:
+        type: integer
+      version:
         type: string
     type: object
   model.DiscordGuild:
@@ -1557,7 +1557,7 @@ definitions:
         type: boolean
       available_cmds:
         items:
-          $ref: '#/definitions/model.AvailableCMD'
+          $ref: '#/definitions/model.DiscordCMD'
         type: array
       global_xp:
         type: boolean
@@ -2487,7 +2487,7 @@ definitions:
         type: string
       available_cmds:
         items:
-          $ref: '#/definitions/model.AvailableCMD'
+          $ref: '#/definitions/model.DiscordCMD'
         type: array
       bot_scopes:
         items:
@@ -2726,13 +2726,13 @@ definitions:
         type: string
       usd:
         type: number
+      usd_14d_change:
+        type: number
       usd_1h_change:
         type: number
       usd_1y_change:
         type: number
       usd_7d_change:
-        type: number
-      usd_14d_change:
         type: number
       usd_24h_change:
         type: number
@@ -3354,12 +3354,6 @@ definitions:
         additionalProperties:
           type: number
         type: object
-      price_change_percentage_7d:
-        type: number
-      price_change_percentage_7d_in_currency:
-        additionalProperties:
-          type: number
-        type: object
       price_change_percentage_14d:
         type: number
       price_change_percentage_14d_in_currency:
@@ -3375,6 +3369,12 @@ definitions:
       price_change_percentage_1y:
         type: number
       price_change_percentage_1y_in_currency:
+        additionalProperties:
+          type: number
+        type: object
+      price_change_percentage_7d:
+        type: number
+      price_change_percentage_7d_in_currency:
         additionalProperties:
           type: number
         type: object

--- a/migrations/schemas/20231031114959-add_available_cmds_to_guilds.sql
+++ b/migrations/schemas/20231031114959-add_available_cmds_to_guilds.sql
@@ -1,7 +1,7 @@
 
 -- +migrate Up
 
-ALTER TABLE discord_guilds ADD COLUMN available_cmds TEXT DEFAULT NULL;
+ALTER TABLE discord_guilds ADD COLUMN available_cmds JSONB DEFAULT NULL;
 
 -- +migrate Down
 

--- a/migrations/schemas/20231031114959-add_available_cmds_to_guilds.sql
+++ b/migrations/schemas/20231031114959-add_available_cmds_to_guilds.sql
@@ -1,7 +1,7 @@
 
 -- +migrate Up
 
-ALTER TABLE discord_guilds ADD COLUMN available_cmds TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE discord_guilds ADD COLUMN available_cmds TEXT DEFAULT NULL;
 
 -- +migrate Down
 

--- a/migrations/schemas/20231031114959-add_available_cmds_to_guilds.sql
+++ b/migrations/schemas/20231031114959-add_available_cmds_to_guilds.sql
@@ -1,0 +1,8 @@
+
+-- +migrate Up
+
+ALTER TABLE discord_guilds ADD COLUMN available_cmds TEXT NOT NULL DEFAULT '[]';
+
+-- +migrate Down
+
+ALTER TABLE discord_guilds DROP COLUMN IF EXISTS available_cmds;

--- a/pkg/entities/guild.go
+++ b/pkg/entities/guild.go
@@ -1,6 +1,8 @@
 package entities
 
 import (
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -168,6 +170,14 @@ func (e *Entity) UpdateGuild(guildID string, req request.UpdateGuildRequest) err
 	}
 	if req.LeftAt != nil {
 		guild.LeftAt = req.LeftAt
+	}
+	if req.AvailableCMDs != nil {
+		jsonData, err := json.Marshal(req.AvailableCMDs)
+		if err != nil {
+			e.log.Errorf(err, "failed to marshal available cmds")
+			return err
+		}
+		guild.AvailableCMDs.NullString = sql.NullString{String: string(jsonData), Valid: true}
 	}
 	if err := e.repo.DiscordGuilds.Update(guild); err != nil {
 		e.log.Errorf(err, "failed to update guild %s", guildID)

--- a/pkg/model/discord_guild.go
+++ b/pkg/model/discord_guild.go
@@ -2,6 +2,20 @@ package model
 
 import "time"
 
+type AvailableCMD struct {
+	ID                       string `json:"id"`
+	ApplicationID            string `json:"application_id"`
+	Version                  string `json:"version"`
+	DefaultMemberPermissions *int   `json:"default_member_permissions"`
+	Type                     int    `json:"type"`
+	Name                     string `json:"name"`
+	NameLocalizations        string `json:"name_localizations"`
+	Description              string `json:"description"`
+	DescriptionLocalizations string `json:"description_localizations"`
+	GuildID                  string `json:"guild_id"`
+	NSFW                     bool   `json:"nsfw"`
+}
+
 type DiscordGuild struct {
 	ID            string          `json:"id"`
 	Name          string          `json:"name"`

--- a/pkg/model/discord_guild.go
+++ b/pkg/model/discord_guild.go
@@ -28,5 +28,5 @@ type DiscordGuild struct {
 	Active        bool            `json:"active"`
 	JoinedAt      time.Time       `json:"-"`
 	LeftAt        *time.Time      `json:"-"`
-	AvailableCMDs JSONNullString  `json:"available_cmds"`
+	AvailableCMDs JSONNullString  `json:"available_cmds" gorm:"column:available_cmds"`
 }

--- a/pkg/model/discord_guild.go
+++ b/pkg/model/discord_guild.go
@@ -3,15 +3,16 @@ package model
 import "time"
 
 type DiscordGuild struct {
-	ID         string          `json:"id"`
-	Name       string          `json:"name"`
-	BotScopes  JSONArrayString `json:"bot_scopes"`
-	Alias      string          `json:"alias"`
-	Roles      []GuildRole     `json:"roles" gorm:"foreignkey:GuildID"`
-	CreatedAt  time.Time       `json:"created_at"`
-	GlobalXP   bool            `json:"global_xp"`
-	LogChannel string          `json:"log_channel"`
-	Active     bool            `json:"active"`
-	JoinedAt   time.Time       `json:"-"`
-	LeftAt     *time.Time      `json:"-"`
+	ID            string          `json:"id"`
+	Name          string          `json:"name"`
+	BotScopes     JSONArrayString `json:"bot_scopes"`
+	Alias         string          `json:"alias"`
+	Roles         []GuildRole     `json:"roles" gorm:"foreignkey:GuildID"`
+	CreatedAt     time.Time       `json:"created_at"`
+	GlobalXP      bool            `json:"global_xp"`
+	LogChannel    string          `json:"log_channel"`
+	Active        bool            `json:"active"`
+	JoinedAt      time.Time       `json:"-"`
+	LeftAt        *time.Time      `json:"-"`
+	AvailableCMDs JSONNullString  `json:"available_cmds"`
 }

--- a/pkg/model/discord_guild.go
+++ b/pkg/model/discord_guild.go
@@ -2,7 +2,7 @@ package model
 
 import "time"
 
-type AvailableCMD struct {
+type DiscordCMD struct {
 	ID                       string `json:"id"`
 	ApplicationID            string `json:"application_id"`
 	Version                  string `json:"version"`

--- a/pkg/request/guild.go
+++ b/pkg/request/guild.go
@@ -13,11 +13,11 @@ type CreateGuildRequest struct {
 }
 
 type UpdateGuildRequest struct {
-	GlobalXP      *bool                 `json:"global_xp"`
-	LogChannel    *string               `json:"log_channel"`
-	Active        *bool                 `json:"active"`
-	LeftAt        *time.Time            `json:"left_at"`
-	AvailableCMDs *[]model.AvailableCMD `json:"available_cmds"`
+	GlobalXP      *bool               `json:"global_xp"`
+	LogChannel    *string             `json:"log_channel"`
+	Active        *bool               `json:"active"`
+	LeftAt        *time.Time          `json:"left_at"`
+	AvailableCMDs *[]model.DiscordCMD `json:"available_cmds"`
 }
 
 type HandleGuildDeleteRequest struct {

--- a/pkg/request/guild.go
+++ b/pkg/request/guild.go
@@ -1,6 +1,10 @@
 package request
 
-import "time"
+import (
+	"time"
+
+	"github.com/defipod/mochi/pkg/model"
+)
 
 type CreateGuildRequest struct {
 	ID       string    `json:"id"`
@@ -8,26 +12,12 @@ type CreateGuildRequest struct {
 	JoinedAt time.Time `json:"-"`
 }
 
-type AvailableCMD struct {
-	ID                       string `json:"id"`
-	ApplicationID            string `json:"application_id"`
-	Version                  string `json:"version"`
-	DefaultMemberPermissions *int   `json:"default_member_permissions"`
-	Type                     int    `json:"type"`
-	Name                     string `json:"name"`
-	NameLocalizations        string `json:"name_localizations"`
-	Description              string `json:"description"`
-	DescriptionLocalizations string `json:"description_localizations"`
-	GuildID                  string `json:"guild_id"`
-	NSFW                     bool   `json:"nsfw"`
-}
-
 type UpdateGuildRequest struct {
-	GlobalXP      *bool           `json:"global_xp"`
-	LogChannel    *string         `json:"log_channel"`
-	Active        *bool           `json:"active"`
-	LeftAt        *time.Time      `json:"left_at"`
-	AvailableCMDs *[]AvailableCMD `json:"available_cmds"`
+	GlobalXP      *bool                 `json:"global_xp"`
+	LogChannel    *string               `json:"log_channel"`
+	Active        *bool                 `json:"active"`
+	LeftAt        *time.Time            `json:"left_at"`
+	AvailableCMDs *[]model.AvailableCMD `json:"available_cmds"`
 }
 
 type HandleGuildDeleteRequest struct {

--- a/pkg/request/guild.go
+++ b/pkg/request/guild.go
@@ -8,11 +8,26 @@ type CreateGuildRequest struct {
 	JoinedAt time.Time `json:"-"`
 }
 
+type AvailableCMD struct {
+	ID                       string `json:"id"`
+	ApplicationID            string `json:"application_id"`
+	Version                  string `json:"version"`
+	DefaultMemberPermissions *int   `json:"default_member_permissions"`
+	Type                     int    `json:"type"`
+	Name                     string `json:"name"`
+	NameLocalizations        string `json:"name_localizations"`
+	Description              string `json:"description"`
+	DescriptionLocalizations string `json:"description_localizations"`
+	GuildID                  string `json:"guild_id"`
+	NSFW                     bool   `json:"nsfw"`
+}
+
 type UpdateGuildRequest struct {
-	GlobalXP   *bool      `json:"global_xp"`
-	LogChannel *string    `json:"log_channel"`
-	Active     *bool      `json:"active"`
-	LeftAt     *time.Time `json:"left_at"`
+	GlobalXP      *bool           `json:"global_xp"`
+	LogChannel    *string         `json:"log_channel"`
+	Active        *bool           `json:"active"`
+	LeftAt        *time.Time      `json:"left_at"`
+	AvailableCMDs *[]AvailableCMD `json:"available_cmds"`
 }
 
 type HandleGuildDeleteRequest struct {

--- a/pkg/response/guild.go
+++ b/pkg/response/guild.go
@@ -11,16 +11,16 @@ type GetGuildsResponse struct {
 }
 
 type GetGuildResponse struct {
-	ID            string                `json:"id"`
-	Name          string                `json:"name"`
-	BotScopes     []string              `json:"bot_scopes"`
-	Alias         string                `json:"alias"`
-	LogChannel    string                `json:"log_channel"`
-	LogChannelID  string                `json:"log_channel_id"`
-	GlobalXP      bool                  `json:"global_xp"`
-	Active        bool                  `json:"active"`
-	Icon          string                `json:"icon"`
-	AvailableCMDs *[]model.AvailableCMD `json:"available_cmds"`
+	ID            string              `json:"id"`
+	Name          string              `json:"name"`
+	BotScopes     []string            `json:"bot_scopes"`
+	Alias         string              `json:"alias"`
+	LogChannel    string              `json:"log_channel"`
+	LogChannelID  string              `json:"log_channel_id"`
+	GlobalXP      bool                `json:"global_xp"`
+	Active        bool                `json:"active"`
+	Icon          string              `json:"icon"`
+	AvailableCMDs *[]model.DiscordCMD `json:"available_cmds"`
 }
 
 type ListAllCustomTokenResponse struct {

--- a/pkg/response/guild.go
+++ b/pkg/response/guild.go
@@ -11,15 +11,16 @@ type GetGuildsResponse struct {
 }
 
 type GetGuildResponse struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	BotScopes    []string `json:"bot_scopes"`
-	Alias        string   `json:"alias"`
-	LogChannel   string   `json:"log_channel"`
-	LogChannelID string   `json:"log_channel_id"`
-	GlobalXP     bool     `json:"global_xp"`
-	Active       bool     `json:"active"`
-	Icon         string   `json:"icon"`
+	ID            string                `json:"id"`
+	Name          string                `json:"name"`
+	BotScopes     []string              `json:"bot_scopes"`
+	Alias         string                `json:"alias"`
+	LogChannel    string                `json:"log_channel"`
+	LogChannelID  string                `json:"log_channel_id"`
+	GlobalXP      bool                  `json:"global_xp"`
+	Active        bool                  `json:"active"`
+	Icon          string                `json:"icon"`
+	AvailableCMDs *[]model.AvailableCMD `json:"available_cmds"`
 }
 
 type ListAllCustomTokenResponse struct {


### PR DESCRIPTION
## What's this PR does ?
- store cmds that a guild is using

## DoD

- [x] Is it public API in [documentation](https://docs.mochi.gg)? Any docs update required ?
- [ ] Does it change the response data shape ?
- [ ] Is it require to update the mock data in [preview](https://github.com/consolelabs/data-mock) ?
- [ ] Include the sample call / example in this PR
