### PR TITLE
fix: friendtech svc is missing initiating sentry

### DIFF
--- a/pkg/service/friendtech/friend_tech.go
+++ b/pkg/service/friendtech/friend_tech.go
@@ -32,6 +32,7 @@ func NewService(cfg *config.Config, sentry sentrygo.Service) Service {
 
 	return &FriendTech{
 		baseUrl: baseUrl,
+		sentry:  sentry,
 	}
 }
 


### PR DESCRIPTION
## What's this PR does ?

- Issue1: Someone added sentry for this service without initiating.
- Issue2: FriendTech change api endpoint: `FRIEND_SCAN_API='https://api.friendscan.io'`