### PR TITLE
chore: add proxy options when connect browserless host

### DIFF
--- a/pkg/service/geckoterminal/geckoterminal.go
+++ b/pkg/service/geckoterminal/geckoterminal.go
@@ -48,7 +48,7 @@ func NewService(cfg *config.Config, l logger.Logger, cache cache.Cache) Service 
 }
 
 func (g *GeckoTerminal) Search(query string) (*Search, error) {
-	browser := rod.New().ControlURL(launcher.MustResolveURL(g.chromeHost)).MustConnect()
+	browser := rod.New().ControlURL(launcher.MustResolveURL(g.chromeHost + "?proxy=residential&proxyCountry=us&proxySticky")).MustConnect()
 	defer browser.MustClose()
 	page := stealth.MustPage(browser).MustNavigate(fmt.Sprintf(searchApi, query))
 


### PR DESCRIPTION
Got this error when trying to call gecko terminal API
```
 app.geckoterminal.com\nChecking if the site connection is secure\napp.geckoterminal.com needs to review the security of your connection before proceeding.\nRay ID: 84085bd5addd48f4\nPerformance \u0026 security by Cloudflare
```
Look relate to bot restriction mechanism of web. So maybe we need using proxy to avoid it.