### PR TITLE
fix: revert logic of SearchCoins

### DIFF
--- a/pkg/entities/defi.go
+++ b/pkg/entities/defi.go
@@ -501,7 +501,7 @@ func (e *Entity) getCoingeckoTokenPlatform(platformID string) (platform *respons
 	return
 }
 
-func (e *Entity) SearchCoins(query, guildId string, noDefault bool, queryBySymbol bool) ([]model.CoingeckoSupportedTokens, error) {
+func (e *Entity) SearchCoins(query, guildId string, noDefault bool) ([]model.CoingeckoSupportedTokens, error) {
 	// TODO: do we need this?
 	if query == "skull" {
 		query = "skullswap-exchange"
@@ -511,56 +511,43 @@ func (e *Entity) SearchCoins(query, guildId string, noDefault bool, queryBySymbo
 		return nil, errors.New("query is required")
 	}
 
-	// TODO: refactor from line to line
-	// Issue: this SearchCoins() is used by ticker and watchlist
-	// - in watchlist we need to handle case coingecko_id = symbol and get only that token (1 token)
-	// - in ticker we dont handle that, just get list and check most popular one
-	// => for now temporary solution is to use queryBySymbol to handle that case and refactor logic later
+	// 1. Get coin with id = query, if it exists then check if that coin is still supported
 	var err error
+	token, err := e.repo.CoingeckoSupportedTokens.GetOne(query)
+	if err != nil && err != gorm.ErrRecordNotFound {
+		e.log.Fields(logger.Fields{"query": query}).Error(err, "[entity.SearchCoins] repo.CoingeckoSupportedTokens.GetOne() failed")
+		return nil, err
+	}
+
+	if token.ID == "" {
+		err = fmt.Errorf("token not found")
+	} else {
+		// need to recheck to see if coingecko still support this tokenID
+		_, err, statusCode := e.svc.CoinGecko.GetCoin(token.ID)
+		if err != nil || statusCode == 404 {
+			e.log.Fields(logger.Fields{"query": query}).Error(err, "[entity.SearchCoins] svc.CoinGecko.GetCoin() failed - token not supported anymore")
+		}
+	}
+
+	// 2. After get data case id = query
+	// - check if token is still supported -> return only that token
+	// - token is not supported anymore -> find list by symbol from table coingecko_supported_tokens. And remove non supported tokens from list tokens
 	var tokens []model.CoingeckoSupportedTokens
-	if queryBySymbol {
+	switch true {
+	case err == nil:
+		tokens = append(tokens, *token)
+
+	default:
 		tokens, err = e.repo.CoingeckoSupportedTokens.List(coingeckosupportedtokens.ListQuery{Symbol: query})
 		if err != nil {
 			e.log.Fields(logger.Fields{"query": query}).Error(err, "[entity.SearchCoins] repo.CoingeckoSupportedTokens.List() failed")
 			return nil, err
 		}
-	} else {
-		// 1. Get coin with id = query, if it exists then check if that coin is still supported
-		token, err := e.repo.CoingeckoSupportedTokens.GetOne(query)
-		if err != nil && err != gorm.ErrRecordNotFound {
-			e.log.Fields(logger.Fields{"query": query}).Error(err, "[entity.SearchCoins] repo.CoingeckoSupportedTokens.GetOne() failed")
-			return nil, err
-		}
 
-		if token.ID == "" {
-			err = fmt.Errorf("token not found")
-		} else {
-			// need to recheck to see if coingecko still support this tokenID
-			_, err, statusCode := e.svc.CoinGecko.GetCoin(token.ID)
-			if err != nil || statusCode == 404 {
-				e.log.Fields(logger.Fields{"query": query}).Error(err, "[entity.SearchCoins] svc.CoinGecko.GetCoin() failed - token not supported anymore")
-			}
-		}
-
-		// 2. After get data case id = query
-		// - check if token is still supported -> return only that token
-		// - token is not supported anymore -> find list by symbol from table coingecko_supported_tokens. And remove non supported tokens from list tokens
-		switch true {
-		case err == nil:
-			tokens = append(tokens, *token)
-
-		default:
-			tokens, err = e.repo.CoingeckoSupportedTokens.List(coingeckosupportedtokens.ListQuery{Symbol: query})
-			if err != nil {
-				e.log.Fields(logger.Fields{"query": query}).Error(err, "[entity.SearchCoins] repo.CoingeckoSupportedTokens.List() failed")
-				return nil, err
-			}
-
-			// remove non-supported tokens if exist
-			for idx, t := range tokens {
-				if t.ID == token.ID {
-					tokens = append(tokens[:idx], tokens[idx+1:]...)
-				}
+		// remove non-supported tokens if exist
+		for idx, t := range tokens {
+			if t.ID == token.ID {
+				tokens = append(tokens[:idx], tokens[idx+1:]...)
 			}
 		}
 	}
@@ -715,7 +702,7 @@ func (e *Entity) queryCoins(guildID, query string) ([]model.CoingeckoSupportedTo
 	}
 
 	// ... else SearchCoins()
-	searchResult, err := e.SearchCoins(query, "", false, false)
+	searchResult, err := e.SearchCoins(query, "", false)
 	// searchResult, err, code := e.svc.CoinGecko.SearchCoins(query)
 	if err != nil {
 		e.log.Fields(logger.Fields{"query": query}).Error(err, "[entity.queryCoins] svc.CoinGecko.SearchCoins failed")
@@ -977,7 +964,7 @@ func (e *Entity) AddToWatchlist(req request.AddToWatchlistRequest) (*response.Ad
 		req.CoinGeckoID = fmt.Sprintf("%s/%s", data.BaseCoin.ID, data.TargetCoin.ID)
 
 	case !isPair && req.CoinGeckoID == "":
-		tokens, err := e.SearchCoins(req.Symbol, "", false, false)
+		tokens, err := e.SearchCoins(req.Symbol, "", false)
 		// coins, err, code := e.svc.CoinGecko.SearchCoins(req.Symbol)
 		if err != nil {
 			e.log.Fields(logger.Fields{"symbol": req.Symbol}).Error(err, "[entity.AddToWatchlist] svc.CoinGecko.SearchCoins() failed")
@@ -1485,7 +1472,7 @@ func (e *Entity) GetDominanceChartData(coinId string, days int) (*response.CoinP
 
 func (e *Entity) GetTokenPrice(symbol string, tokenName string) (*float64, error) {
 	var price float64
-	tokens, err := e.SearchCoins(strings.ToLower(symbol), "", false, false)
+	tokens, err := e.SearchCoins(strings.ToLower(symbol), "", false)
 	if err != nil {
 		e.log.Fields(logger.Fields{"symbol": strings.ToLower(symbol)}).Error(err, "[listSuiWalletAssets] svc.CoinGecko.SearchCoins() failed")
 		return nil, err

--- a/pkg/entities/tokens.go
+++ b/pkg/entities/tokens.go
@@ -30,7 +30,7 @@ func (e *Entity) CreateCustomToken(req request.UpsertCustomTokenConfigRequest) e
 		return fmt.Errorf("error getting chain: %v", err)
 	}
 
-	coins, err := e.SearchCoins(req.Symbol, "", false, false)
+	coins, err := e.SearchCoins(req.Symbol, "", false)
 	if err != nil {
 		e.log.Error(err, "[Entity][CreateCustomToken] svc.CoinGecko.SearchCoins failed")
 		return fmt.Errorf("error seaching coin: %v", err)

--- a/pkg/handler/defi/defi.go
+++ b/pkg/handler/defi/defi.go
@@ -162,7 +162,7 @@ func (h *Handler) SearchCoins(c *gin.Context) {
 		return
 	}
 
-	tokens, err := h.entities.SearchCoins(req.Query, req.GuildId, req.NoDefault, true)
+	tokens, err := h.entities.SearchCoins(req.Query, req.GuildId, req.NoDefault)
 	if err != nil {
 		h.log.Error(err, "[handler.SearchCoins] entities.SearchCoins() failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})


### PR DESCRIPTION
## What's this PR does ?
SearchCoins: revert logic
- Reason: we should not force search coins API to query by symbol. This may reproduce a legacy bug so just keep tracking