### PR TITLE
feat: add binance future data resp in api user balances

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9806,6 +9806,38 @@ const docTemplate = `{
                 }
             }
         },
+        "response.BinanceFutureAccountBalance": {
+            "type": "object",
+            "properties": {
+                "accountAlias": {
+                    "type": "string"
+                },
+                "asset": {
+                    "type": "string"
+                },
+                "availableBalance": {
+                    "type": "string"
+                },
+                "balance": {
+                    "type": "string"
+                },
+                "crossUnPnl": {
+                    "type": "string"
+                },
+                "crossWalletBalance": {
+                    "type": "string"
+                },
+                "marginAvailable": {
+                    "type": "boolean"
+                },
+                "maxWithdrawAmount": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "integer"
+                }
+            }
+        },
         "response.BinanceFutureAccountPositionResponse": {
             "type": "object",
             "properties": {
@@ -10697,6 +10729,32 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.DaoProposal"
                     }
+                }
+            }
+        },
+        "response.GetBinanceAsset": {
+            "type": "object",
+            "properties": {
+                "asset": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.WalletAssetData"
+                    }
+                },
+                "earn": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.WalletAssetData"
+                    }
+                },
+                "future": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.BinanceFutureAccountBalance"
+                    }
+                },
+                "simple_earn": {
+                    "$ref": "#/definitions/response.WalletBinanceAssetSimpleEarnResponse"
                 }
             }
         },
@@ -13485,10 +13543,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "binance": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/response.WalletAssetData"
-                    }
+                    "$ref": "#/definitions/response.GetBinanceAsset"
                 }
             }
         },
@@ -13626,6 +13681,32 @@ const docTemplate = `{
                 },
                 "usd_balance": {
                     "type": "number"
+                }
+            }
+        },
+        "response.WalletBinanceAssetSimpleEarnResponse": {
+            "type": "object",
+            "properties": {
+                "btc_price": {
+                    "type": "string"
+                },
+                "total_amount_in_btc": {
+                    "type": "string"
+                },
+                "total_amount_in_usdt": {
+                    "type": "string"
+                },
+                "total_flexible_amount_in_btc": {
+                    "type": "string"
+                },
+                "total_flexible_amount_in_usdt": {
+                    "type": "string"
+                },
+                "total_locked_in_btc": {
+                    "type": "string"
+                },
+                "total_locked_in_usdt": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9798,6 +9798,38 @@
                 }
             }
         },
+        "response.BinanceFutureAccountBalance": {
+            "type": "object",
+            "properties": {
+                "accountAlias": {
+                    "type": "string"
+                },
+                "asset": {
+                    "type": "string"
+                },
+                "availableBalance": {
+                    "type": "string"
+                },
+                "balance": {
+                    "type": "string"
+                },
+                "crossUnPnl": {
+                    "type": "string"
+                },
+                "crossWalletBalance": {
+                    "type": "string"
+                },
+                "marginAvailable": {
+                    "type": "boolean"
+                },
+                "maxWithdrawAmount": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "integer"
+                }
+            }
+        },
         "response.BinanceFutureAccountPositionResponse": {
             "type": "object",
             "properties": {
@@ -10689,6 +10721,32 @@
                     "items": {
                         "$ref": "#/definitions/model.DaoProposal"
                     }
+                }
+            }
+        },
+        "response.GetBinanceAsset": {
+            "type": "object",
+            "properties": {
+                "asset": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.WalletAssetData"
+                    }
+                },
+                "earn": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.WalletAssetData"
+                    }
+                },
+                "future": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.BinanceFutureAccountBalance"
+                    }
+                },
+                "simple_earn": {
+                    "$ref": "#/definitions/response.WalletBinanceAssetSimpleEarnResponse"
                 }
             }
         },
@@ -13477,10 +13535,7 @@
             "type": "object",
             "properties": {
                 "binance": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/response.WalletAssetData"
-                    }
+                    "$ref": "#/definitions/response.GetBinanceAsset"
                 }
             }
         },
@@ -13618,6 +13673,32 @@
                 },
                 "usd_balance": {
                     "type": "number"
+                }
+            }
+        },
+        "response.WalletBinanceAssetSimpleEarnResponse": {
+            "type": "object",
+            "properties": {
+                "btc_price": {
+                    "type": "string"
+                },
+                "total_amount_in_btc": {
+                    "type": "string"
+                },
+                "total_amount_in_usdt": {
+                    "type": "string"
+                },
+                "total_flexible_amount_in_btc": {
+                    "type": "string"
+                },
+                "total_flexible_amount_in_usdt": {
+                    "type": "string"
+                },
+                "total_locked_in_btc": {
+                    "type": "string"
+                },
+                "total_locked_in_usdt": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2065,6 +2065,27 @@ definitions:
       type:
         type: string
     type: object
+  response.BinanceFutureAccountBalance:
+    properties:
+      accountAlias:
+        type: string
+      asset:
+        type: string
+      availableBalance:
+        type: string
+      balance:
+        type: string
+      crossUnPnl:
+        type: string
+      crossWalletBalance:
+        type: string
+      marginAvailable:
+        type: boolean
+      maxWithdrawAmount:
+        type: string
+      updateTime:
+        type: integer
+    type: object
   response.BinanceFutureAccountPositionResponse:
     properties:
       data:
@@ -2647,6 +2668,23 @@ definitions:
         items:
           $ref: '#/definitions/model.DaoProposal'
         type: array
+    type: object
+  response.GetBinanceAsset:
+    properties:
+      asset:
+        items:
+          $ref: '#/definitions/response.WalletAssetData'
+        type: array
+      earn:
+        items:
+          $ref: '#/definitions/response.WalletAssetData'
+        type: array
+      future:
+        items:
+          $ref: '#/definitions/response.BinanceFutureAccountBalance'
+        type: array
+      simple_earn:
+        $ref: '#/definitions/response.WalletBinanceAssetSimpleEarnResponse'
     type: object
   response.GetCoinResponse:
     properties:
@@ -3729,10 +3767,6 @@ definitions:
         type: object
       price_change_percentage_14d:
         type: number
-      price_change_percentage_14d_in_currency:
-        additionalProperties:
-          type: number
-        type: object
       price_change_percentage_1h:
         type: number
       price_change_percentage_1h_in_currency:
@@ -3741,13 +3775,17 @@ definitions:
         type: object
       price_change_percentage_1y:
         type: number
-      price_change_percentage_1y_in_currency:
-        additionalProperties:
-          type: number
-        type: object
       price_change_percentage_7d:
         type: number
       price_change_percentage_7d_in_currency:
+        additionalProperties:
+          type: number
+        type: object
+      price_change_percentage_14d_in_currency:
+        additionalProperties:
+          type: number
+        type: object
+      price_change_percentage_1y_in_currency:
         additionalProperties:
           type: number
         type: object
@@ -4460,9 +4498,7 @@ definitions:
   response.UserBalanceCex:
     properties:
       binance:
-        items:
-          $ref: '#/definitions/response.WalletAssetData'
-        type: array
+        $ref: '#/definitions/response.GetBinanceAsset'
     type: object
   response.UserBalanceOnchain:
     properties:
@@ -4552,6 +4588,23 @@ definitions:
         $ref: '#/definitions/response.AssetToken'
       usd_balance:
         type: number
+    type: object
+  response.WalletBinanceAssetSimpleEarnResponse:
+    properties:
+      btc_price:
+        type: string
+      total_amount_in_btc:
+        type: string
+      total_amount_in_usdt:
+        type: string
+      total_flexible_amount_in_btc:
+        type: string
+      total_flexible_amount_in_usdt:
+        type: string
+      total_locked_in_btc:
+        type: string
+      total_locked_in_usdt:
+        type: string
     type: object
   util.Pagination:
     properties:

--- a/pkg/entities/wallet.go
+++ b/pkg/entities/wallet.go
@@ -1055,6 +1055,13 @@ func (e *Entity) GetBinanceAssets(req request.GetBinanceAssetsRequest) (*respons
 		return nil, "", "", err
 	}
 
+	// get future asset data from binance or cache
+	futureAsset, err := e.svc.Binance.GetFutureAccountBalance(apiKey, apiSecret)
+	if err != nil {
+		e.log.Fields(logger.Fields{"req": req}).Error(err, "[entities.GetBinanceAssets] svc.Binance.GetFutureAccountBalance fail")
+		return nil, "", "", err
+	}
+
 	// format asset
 	formatFundingAsset, err := e.FormatAsset(fundingAsset)
 	if err != nil {
@@ -1082,8 +1089,9 @@ func (e *Entity) GetBinanceAssets(req request.GetBinanceAssetsRequest) (*respons
 		return nil, "", "", err
 	}
 	return &response.GetBinanceAsset{
-		Asset: formatFundingAsset,
-		Earn:  formatEarnAsset,
+		Asset:  formatFundingAsset,
+		Earn:   formatEarnAsset,
+		Future: futureAsset,
 		SimpleEarn: response.WalletBinanceAssetSimpleEarnResponse{
 			TotalAmountInBTC:          simpleEarnAcc.TotalAmountInBTC,
 			TotalAmountInUSDT:         simpleEarnAcc.TotalAmountInUSDT,

--- a/pkg/response/user.go
+++ b/pkg/response/user.go
@@ -103,5 +103,5 @@ type UserBalanceOnchain struct {
 }
 
 type UserBalanceCex struct {
-	Binance []WalletAssetData `json:"binance"`
+	Binance *GetBinanceAsset `json:"binance"`
 }

--- a/pkg/response/wallet.go
+++ b/pkg/response/wallet.go
@@ -107,6 +107,7 @@ type WalletBinanceAssetResponse struct {
 type GetBinanceAsset struct {
 	Asset      []WalletAssetData                    `json:"asset"`
 	Earn       []WalletAssetData                    `json:"earn"`
+	Future     []BinanceFutureAccountBalance        `json:"future"`
 	SimpleEarn WalletBinanceAssetSimpleEarnResponse `json:"simple_earn"`
 }
 


### PR DESCRIPTION
## What's this PR does ?

 Add binance future api data resp
## Which UI commands affect by this change ?

e.g: /balances
## DoD

- [ ] Is it public API in [documentation](https://docs.mochi.gg)? Any docs update required ?
- [ ] Does it change the response data shape ?
- [ ] Is it require to update the mock data in [preview](https://github.com/consolelabs/data-mock) ?
- [ ] Include the sample call / example in this PR
