### PR TITLE
fix(covalent): remove sentry log for covalent rate limit

### DIFF
--- a/pkg/service/covalent/adapter.go
+++ b/pkg/service/covalent/adapter.go
@@ -41,7 +41,7 @@ func (c *Covalent) doNetworkSolanaTokenBalances(chainName string, address string
 	if res.Error {
 		if retry == 0 {
 			c.sentry.CaptureErrorEvent(sentrygo.SentryCapturePayload{
-				Message: fmt.Sprintf("[API mochi] - Covalent - doNetworkTokenBalances failed %v", err),
+				Message: fmt.Sprintf("[API mochi] - Covalent - doNetworkTokenBalances failed %v", res.Error),
 				Tags:    sentryTags,
 				Extra: map[string]interface{}{
 					"chainName": chainName,


### PR DESCRIPTION
## What's this PR does ?

- [x] remove sentry log for covalent rate limit
- I tried to spam the get solana balance from covalent api but could not reproduce the bug, so I kept the sentry log and replaced `err `-> `res.Error`, if the sentry log occurs again, I can know the cause of the error and handle it later.