### PR TITLE
fix: self calculate market cap if not supported

### DIFF
--- a/pkg/response/defi.go
+++ b/pkg/response/defi.go
@@ -69,7 +69,7 @@ type GetCoinResponse struct {
 	Symbol                       string                            `json:"symbol"`
 	AssetPlatformID              string                            `json:"asset_platform_id"`
 	AssetPlatform                *AssetPlatformResponseData        `json:"asset_platform"`
-	Platforms                    interface{}                       `json:"platforms"`
+	Platforms                    map[string]string                 `json:"platforms"`
 	BlockTimeInMinutes           int64                             `json:"block_time_in_minutes"`
 	HashingAlgorithm             interface{}                       `json:"hashing_algorithm"`
 	Categories                   []string                          `json:"categories"`

--- a/pkg/util/solana.go
+++ b/pkg/util/solana.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"context"
+	"math"
+
+	"github.com/portto/solana-go-sdk/client"
+	"github.com/portto/solana-go-sdk/rpc"
+)
+
+func GetSplTokenSupply(addr string) (float64, error) {
+	c := client.NewClient(rpc.MainnetRPCEndpoint)
+	supply, dec, err := c.GetTokenSupply(context.Background(), addr)
+	if err != nil {
+		return 0, err
+	}
+
+	result := float64(supply) / math.Pow10(int(dec))
+	return result, nil
+}


### PR DESCRIPTION
## What's this PR does ?
Get coin: self calculate market cap if data is not supported by coingecko
- [x] Solana
- [ ] Other chains