### PR TITLE
fix: get coin - support market cap data for evm tokens

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -316,6 +316,27 @@ func (ch *Chain) Balances(address string, tokens []model.Token) (map[string]floa
 	return balances, nil
 }
 
+func (ch *Chain) TokenTotalSupply(address string, decimal int) (float64, error) {
+	v, err := ch.scan.TokenTotalSupply(address)
+	if err != nil {
+		return 0, err
+	}
+
+	if v == nil {
+		return 0, nil
+	}
+
+	str := v.Int().String()
+	f, ok := new(big.Float).SetString(str)
+	f.Quo(f, big.NewFloat(math.Pow10(decimal)))
+	if !ok {
+		return 0, nil
+	}
+
+	supply, _ := f.Float64()
+	return supply, nil
+}
+
 // func (ch *Chain) RawBalances(address string, tokens []model.Token) (map[string]*big.Int, error) {
 // 	balances := make(map[string]*big.Int, 0)
 // 	for _, token := range tokens {

--- a/pkg/repo/chain/pg.go
+++ b/pkg/repo/chain/pg.go
@@ -31,3 +31,14 @@ func (pg *pg) GetByShortName(shortName string) (*model.Chain, error) {
 	}
 	return chain, nil
 }
+
+func (pg *pg) GetOne(q GetOneQuery) (chain *model.Chain, err error) {
+	db := pg.db
+	if q.CoingeckoId != "" {
+		db = db.Where("coin_gecko_id = ?", q.CoingeckoId)
+	}
+	if q.Type != "" {
+		db = db.Where("\"type\" = ?", q.Type)
+	}
+	return chain, db.First(&chain).Error
+}

--- a/pkg/repo/chain/query.go
+++ b/pkg/repo/chain/query.go
@@ -1,0 +1,6 @@
+package chain
+
+type GetOneQuery struct {
+	CoingeckoId string
+	Type        string
+}

--- a/pkg/repo/chain/store.go
+++ b/pkg/repo/chain/store.go
@@ -6,4 +6,5 @@ type Store interface {
 	GetAll() ([]model.Chain, error)
 	GetByID(id int) (model.Chain, error)
 	GetByShortName(shortName string) (*model.Chain, error)
+	GetOne(GetOneQuery) (*model.Chain, error)
 }


### PR DESCRIPTION
## What's this PR does ?
- Get coin API: support market cap data (if coingecko does not support) for evm-based tokens