### PR TITLE
feat: ticker - add contract renounced

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -376,3 +376,19 @@ func (ch *Chain) RawErc20TokenBalance(address string, token model.Token) (*big.I
 	}
 	return tokenBalance, nil
 }
+
+func (ch *Chain) IsContractRenounced(address string) (bool, error) {
+	req := map[string]string{"to": address, "data": "0x8da5cb5b"}
+	var resp string
+
+	if ch.client.Client() == nil {
+		return false, nil
+	}
+
+	if err := ch.client.Client().Call(&resp, "eth_call", req, "latest"); err != nil {
+		return false, err
+	}
+
+	owner := common.HexToAddress(resp)
+	return strings.EqualFold(owner.String(), common.HexToAddress("0").String()), nil
+}

--- a/pkg/response/defi.go
+++ b/pkg/response/defi.go
@@ -92,6 +92,7 @@ type GetCoinResponse struct {
 	ContractAddress              string                            `json:"contract_address"`
 	DetailPlatforms              map[string]CoinPlatformDetailData `json:"detail_platforms"`
 	IcoData                      *ICOData                          `json:"ico_data"`
+	OwnershipRenouned            bool                              `json:"ownership_renounced"`
 }
 
 type ICOData struct {

--- a/pkg/util/solana.go
+++ b/pkg/util/solana.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/portto/solana-go-sdk/client"
+	"github.com/portto/solana-go-sdk/program/token"
 	"github.com/portto/solana-go-sdk/rpc"
 )
 
@@ -17,4 +18,23 @@ func GetSplTokenSupply(addr string) (float64, error) {
 
 	result := float64(supply) / math.Pow10(int(dec))
 	return result, nil
+}
+
+// If mint authority is diabled, then the contract is considered as "ownership renounced"
+func IsProgramContractRenounced(addr string) (bool, error) {
+	c := client.NewClient(rpc.MainnetRPCEndpoint)
+	accountInfo, err := c.GetAccountInfo(context.Background(), addr)
+	if err != nil {
+		return false, err
+	}
+
+	mintAcc, err := token.MintAccountFromData(accountInfo.Data)
+	if err != nil {
+		return false, err
+	}
+
+	if mintAcc.MintAuthority == nil {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
## What's this PR does ?
- Get coin: new flag `ownership_renounced` to show if the token contract is renounced