### PR TITLE
feat: binance spot average cost

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5642,6 +5642,38 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/{id}/cexs/binance/average-costs": {
+            "get": {
+                "description": "Get user's assets average cost",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Binance"
+                ],
+                "summary": "Get user's assets average cost",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.BinanceFutureAccountPositionResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users/{id}/cexs/binance/positions": {
             "get": {
                 "description": "Get user's future account balance",
@@ -5674,7 +5706,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/{id}/cexs/binance/spot-txs": {
+        "/users/{id}/cexs/binance/spot-txns": {
             "get": {
                 "description": "Get user's spot account txs",
                 "consumes": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5634,6 +5634,38 @@
                 }
             }
         },
+        "/users/{id}/cexs/binance/average-costs": {
+            "get": {
+                "description": "Get user's assets average cost",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Binance"
+                ],
+                "summary": "Get user's assets average cost",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.BinanceFutureAccountPositionResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users/{id}/cexs/binance/positions": {
             "get": {
                 "description": "Get user's future account balance",
@@ -5666,7 +5698,7 @@
                 }
             }
         },
-        "/users/{id}/cexs/binance/spot-txs": {
+        "/users/{id}/cexs/binance/spot-txns": {
             "get": {
                 "description": "Get user's spot account txs",
                 "consumes": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3075,13 +3075,13 @@ definitions:
         type: string
       usd:
         type: number
-      usd_1h_change:
-        type: number
-      usd_1y_change:
-        type: number
       usd_7d_change:
         type: number
       usd_14d_change:
+        type: number
+      usd_1h_change:
+        type: number
+      usd_1y_change:
         type: number
       usd_24h_change:
         type: number
@@ -3715,12 +3715,6 @@ definitions:
         additionalProperties:
           type: number
         type: object
-      price_change_percentage_14d:
-        type: number
-      price_change_percentage_14d_in_currency:
-        additionalProperties:
-          type: number
-        type: object
       price_change_percentage_1h:
         type: number
       price_change_percentage_1h_in_currency:
@@ -3736,6 +3730,12 @@ definitions:
       price_change_percentage_7d:
         type: number
       price_change_percentage_7d_in_currency:
+        additionalProperties:
+          type: number
+        type: object
+      price_change_percentage_14d:
+        type: number
+      price_change_percentage_14d_in_currency:
         additionalProperties:
           type: number
         type: object
@@ -8166,6 +8166,27 @@ paths:
       summary: Find one user's trackng wallet
       tags:
       - Wallet
+  /users/{id}/cexs/binance/average-costs:
+    get:
+      consumes:
+      - application/json
+      description: Get user's assets average cost
+      parameters:
+      - description: profile ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.BinanceFutureAccountPositionResponse'
+      summary: Get user's assets average cost
+      tags:
+      - Binance
   /users/{id}/cexs/binance/positions:
     get:
       consumes:
@@ -8187,7 +8208,7 @@ paths:
       summary: Get user's future account balance
       tags:
       - Binance
-  /users/{id}/cexs/binance/spot-txs:
+  /users/{id}/cexs/binance/spot-txns:
     get:
       consumes:
       - application/json

--- a/migrations/schemas/20240510080916-add-price_in_usd-col-to-binance-txs-table.sql
+++ b/migrations/schemas/20240510080916-add-price_in_usd-col-to-binance-txs-table.sql
@@ -1,0 +1,16 @@
+-- +migrate Up
+ALTER TABLE
+    IF EXISTS binance_spot_transactions
+ADD
+    COLUMN price_in_usd TEXT NOT NULL default '0.0';
+
+UPDATE
+    binance_spot_transactions
+SET
+    price_in_usd = price
+Where
+    price_in_usd = '0.0';
+
+-- +migrate Down
+ALTER TABLE
+    IF EXISTS binance_spot_transactions DROP COLUMN price_in_usd;

--- a/pkg/entities/wallet.go
+++ b/pkg/entities/wallet.go
@@ -1034,6 +1034,15 @@ func (e *Entity) SumarizeBinanceAsset(req request.BinanceRequest) (*response.Wal
 	}, err
 }
 
+func (e *Entity) GetBinanceAverageCost(profileId string) ([]model.BinanceAssetAverageCost, error) {
+	res, err := e.repo.BinanceSpotTransaction.GetUserAverageCost(profileId)
+	if err != nil {
+		e.log.Fields(logger.Fields{"profileId": profileId}).Error(err, "[entities.GetBinanceAssetAverageCost] Failed to get asset average cost of user")
+		return nil, err
+	}
+	return res, nil
+}
+
 func (e *Entity) GetBinanceAssets(req request.GetBinanceAssetsRequest) (*response.GetBinanceAsset, string, string, error) {
 	profile, err := e.svc.MochiProfile.GetByID(req.Id, e.cfg.MochiBotSecret)
 	if err != nil {

--- a/pkg/handler/dex/dex.go
+++ b/pkg/handler/dex/dex.go
@@ -148,3 +148,31 @@ func (h *Handler) GetBinanceSpotTxns(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, response.CreateResponse(res, nil, nil, nil))
 }
+
+// GetBinanceAverageCosts godoc
+// @Summary     Get user's assets average cost
+// @Description Get user's assets average cost
+// @Tags        Binance
+// @Accept      json
+// @Produce     json
+// @Param       id   			path  string true  "profile ID"
+// @Success     200 {object} response.BinanceFutureAccountPositionResponse
+// @Router      /users/{id}/cexs/binance/average-costs [get]
+func (h *Handler) GetBinanceAverageCosts(c *gin.Context) {
+	profileId := c.Param("id")
+	if !util.ValidateNumberSeries(profileId) {
+		err := errors.New("profile Id is invalid")
+		h.log.Error(err, "[handler.GetBinanceFutures] validate profile id failed")
+		c.JSON(http.StatusBadRequest, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+
+	res, err := h.entities.GetBinanceAverageCost(profileId)
+	if err != nil {
+		h.log.Error(err, "[handler.GetBinanceAverageCosts] entity.GetBinanceAverageCosts() failed")
+		c.JSON(http.StatusInternalServerError, response.CreateResponse[any](nil, nil, err, nil))
+		return
+	}
+
+	c.JSON(http.StatusOK, response.CreateResponse(res, nil, nil, nil))
+}

--- a/pkg/handler/dex/interface.go
+++ b/pkg/handler/dex/interface.go
@@ -7,4 +7,5 @@ type IHandler interface {
 	GetBinanceAssets(c *gin.Context)
 	GetBinanceFutures(c *gin.Context)
 	GetBinanceSpotTxns(c *gin.Context)
+	GetBinanceAverageCosts(c *gin.Context)
 }

--- a/pkg/model/binance_asset_average_cost.go
+++ b/pkg/model/binance_asset_average_cost.go
@@ -1,0 +1,7 @@
+package model
+
+type BinanceAssetAverageCost struct {
+	ProfileId   string `json:"profile_id"`
+	Symbol      string `json:"symbol"`
+	AverageCost string `json:"average_cost"`
+}

--- a/pkg/model/binance_spot_transaction.go
+++ b/pkg/model/binance_spot_transaction.go
@@ -11,6 +11,7 @@ type BinanceSpotTransaction struct {
 	OrderListId             int64     `json:"order_list_id"`
 	ClientOrderId           string    `json:"client_order_id"`
 	Price                   string    `json:"price"`
+	PriceInUsd              string    `json:"price_in_usd"`
 	OrigQty                 string    `json:"orig_qty"`
 	ExecutedQty             string    `json:"executed_qty"`
 	CumulativeQuoteQty      string    `json:"cumulative_quote_qty"`

--- a/pkg/repo/binance_spot_transaction/store.go
+++ b/pkg/repo/binance_spot_transaction/store.go
@@ -5,4 +5,5 @@ import "github.com/defipod/mochi/pkg/model"
 type Store interface {
 	Create(tx *model.BinanceSpotTransaction) error
 	List(q ListQuery) ([]model.BinanceSpotTransaction, error)
+	GetUserAverageCost(profileId string) ([]model.BinanceAssetAverageCost, error)
 }

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -67,6 +67,7 @@ func NewRoutes(r *gin.Engine, h *handler.Handler, cfg config.Config) {
 			cexGroup.GET("/binance/positions", h.Dex.GetBinanceFutures)
 			cexGroup.GET("/:platform/assets", h.Dex.GetBinanceAssets)
 			cexGroup.GET("/binance/spot_txns", h.Dex.GetBinanceSpotTxns)
+			cexGroup.GET("/binance/average-costs", h.Dex.GetBinanceAverageCosts)
 		}
 
 		// TODO: remove after migrate

--- a/pkg/scheduler/update-binance-spot-history.go
+++ b/pkg/scheduler/update-binance-spot-history.go
@@ -108,7 +108,8 @@ func (s *updateBinanceSpotHistory) schedulerUpdate() error {
 					priceInUsd := tx.Price
 					if isFilled && (isBtcPair || isEthPair || isBnbPair) {
 						// get price of the symbol at the time of the transaction
-						ticks, err := s.svc.Binance.Kline(tx.Symbol, binance.Interval1m, tx.Time, 0)
+						usdtpair := fmt.Sprintf("%sUSDT", symbol)
+						ticks, err := s.svc.Binance.Kline(usdtpair, binance.Interval1m, tx.Time, 0)
 						if err != nil {
 							s.log.Fields(logger.Fields{"profileId": acc.ProfileId}).Error(err, "[updateBinanceSpotHistory] - svc.Binance.Kline() fail to get kline")
 							break

--- a/pkg/scheduler/update-binance-spot-history.go
+++ b/pkg/scheduler/update-binance-spot-history.go
@@ -12,6 +12,7 @@ import (
 	"github.com/defipod/mochi/pkg/model"
 	"github.com/defipod/mochi/pkg/request"
 	"github.com/defipod/mochi/pkg/service"
+	"github.com/defipod/mochi/pkg/service/binance"
 )
 
 type updateBinanceSpotHistory struct {
@@ -97,6 +98,25 @@ func (s *updateBinanceSpotHistory) schedulerUpdate() error {
 					break
 				}
 				for _, tx := range txs {
+					// If order is filled, and
+					// if the pair order is xxxbtc / xxxeth / xxxbnb we will get the price of symbol in usd
+					// This data will be used to calculate the average price of the symbol
+					isFilled := tx.Status == "FILLED"
+					isBtcPair := strings.HasSuffix(p, "BTC")
+					isEthPair := strings.HasSuffix(p, "ETH")
+					isBnbPair := strings.HasSuffix(p, "BNB")
+					priceInUsd := tx.Price
+					if isFilled && (isBtcPair || isEthPair || isBnbPair) {
+						// get price of the symbol at the time of the transaction
+						ticks, err := s.svc.Binance.Kline(tx.Symbol, binance.Interval1m, tx.Time, 0)
+						if err != nil {
+							s.log.Fields(logger.Fields{"profileId": acc.ProfileId}).Error(err, "[updateBinanceSpotHistory] - svc.Binance.Kline() fail to get kline")
+							break
+						}
+						if len(ticks) > 0 && len(ticks[0]) > 0 {
+							priceInUsd = ticks[0][0]
+						}
+					}
 					err = s.entity.GetRepo().BinanceSpotTransaction.Create(&model.BinanceSpotTransaction{
 						ProfileId:               acc.ProfileId,
 						Symbol:                  symbol,
@@ -105,6 +125,7 @@ func (s *updateBinanceSpotHistory) schedulerUpdate() error {
 						OrderListId:             tx.OrderListId,
 						ClientOrderId:           tx.ClientOrderId,
 						Price:                   tx.Price,
+						PriceInUsd:              priceInUsd,
 						OrigQty:                 tx.OrigQty,
 						ExecutedQty:             tx.ExecutedQty,
 						CumulativeQuoteQty:      tx.CumulativeQuoteQty,

--- a/pkg/service/binance/binance.go
+++ b/pkg/service/binance/binance.go
@@ -521,3 +521,21 @@ func (b *Binance) GetSpotTransactions(apiKey, apiSecret, symbol, startTime, endT
 	// get spot transaction
 	return badapter.GetSpotTransaction(apiKey, apiSecret, symbol, startTime, endTime)
 }
+
+// Get binance candlestick
+type Interval string
+
+const (
+	Interval1m  Interval = "1m"
+	Interval5m  Interval = "5m"
+	Interval15m Interval = "15m"
+	Interval30m Interval = "30m"
+	Interval1h  Interval = "1h"
+	Interval1d  Interval = "1d"
+	Interval1w  Interval = "1w"
+	Interval1M  Interval = "1M"
+)
+
+func (b *Binance) Kline(symbol string, interval Interval, startTime int64, endTime int64) ([][]string, error) {
+	return badapter.Kline(symbol, string(interval), startTime, endTime)
+}

--- a/pkg/service/binance/service.go
+++ b/pkg/service/binance/service.go
@@ -20,4 +20,5 @@ type Service interface {
 	GetFutureAccountInfo(apiKey, apiSecret string) ([]response.BinanceFuturePositionInfo, error)
 	GetPrice(symbol string) (*response.BinanceApiTickerPriceResponse, error)
 	GetSpotTransactions(apiKey, apiSecret, symbol, startTime, endTime string) ([]response.BinanceSpotTransactionResponse, error)
+	Kline(symbol string, interval Interval, startTime int64, endTime int64) ([][]string, error)
 }


### PR DESCRIPTION
## What's this PR does ?

- [x] add price_in_usd for binance_spot_txs
- [x] add api for getting user asset average cost

## Note
- Need to run migrate-up

## Example
```sh
curl --request GET \
  --url 'http://localhost:8200/api/v1/users/43418/cexs/binance/average-costs?base=FTM&guild_id=891310117658705931&interval=30&target=USD'
```

![CleanShot 2024-05-10 at 08 49 43@2x](https://github.com/consolelabs/mochi-api/assets/14150687/4f993fa2-b2f4-4be1-a15e-9db52f453742)


